### PR TITLE
Python 3 support

### DIFF
--- a/Repo.py
+++ b/Repo.py
@@ -29,8 +29,8 @@ class Repo(object):
     def DoCleanup( self, errCode = 0 ):
         self._retcode = errCode
         if self._retcode != 0:
-            traceback.print_tb(sys.exc_traceback)
-            print "%s exited with return code %d." % (sys.argv[0], retcode)
+            traceback.print_tb(sys.exc_info()[2])
+            print("%s exited with return code %d." % (sys.argv[0], retcode))
 
     def __repr__( self ):
         strRep =  '%s("%s",branch=%s,pkg=%s,tag=%s' % ( self.__class__.__name__, self._url, \
@@ -47,22 +47,22 @@ class Repo(object):
 
     def ShowRepo( self, titleLine=None, prefix="" ):
         if titleLine:
-            print titleLine
+            print(titleLine)
         if not self._url:
-            print "%sURL:    Not Set!" % ( prefix )
+            print("%sURL:    Not Set!" % ( prefix ))
         else:
-            print "%sURL:    %s" % ( prefix, self._url )
+            print("%sURL:    %s" % ( prefix, self._url ))
         if self._branch:
-            print "%sbranch: %s" % ( prefix, self._branch )
+            print("%sbranch: %s" % ( prefix, self._branch ))
         if self._tag:
-            print "%stag:    %s" % ( prefix, self._tag )
+            print("%stag:    %s" % ( prefix, self._tag ))
 
     def CheckoutRelease( self, buildDir ):
-        print "\nPlease override Repo.CheckoutRelease() via a version control specific subclass."
+        print("\nPlease override Repo.CheckoutRelease() via a version control specific subclass.")
         os.sys.exit()
 
     def GetDefaultPackage( self, package, verbose=False ):
-        print "\nPlease override Repo.GetDefaultPackage() via a version control specific subclass."
+        print("\nPlease override Repo.GetDefaultPackage() via a version control specific subclass.")
         os.sys.exit()
 
     def GetTag( self ):
@@ -72,9 +72,9 @@ class Repo(object):
         return self._url
 
     def RemoveTag( self, tag=None ):
-        print "\nPlease override Repo.RemoveTag() via a version control specific subclass."
+        print("\nPlease override Repo.RemoveTag() via a version control specific subclass.")
         os.sys.exit()
 
     def TagRelease( self, packagePath=None, release=None, branch=None, message="", verbose=True, dryRun=False ):
-        print "\nPlease override Repo.TagRelease() via a version control specific subclass."
+        print("\nPlease override Repo.TagRelease() via a version control specific subclass.")
         os.sys.exit()

--- a/cram_utils.py
+++ b/cram_utils.py
@@ -6,6 +6,7 @@ import subprocess
 import json
 from git_utils     import *
 from repo_defaults import *
+from functools import reduce
 
 def createCramPackageInfo(packageName, apptype):
     '''Create .cram/packageinfo'''
@@ -15,7 +16,7 @@ def createCramPackageInfo(packageName, apptype):
     packageInfo['type'] = apptype
 
     if not os.path.exists('.cram'):
-        os.makedirs('.cram', 0775 )
+        os.makedirs('.cram', 0o775 )
     packageInfofile = os.path.join('.cram', 'packageinfo')
     with open(packageInfofile, 'w') as pkginfof:
         json.dump(packageInfo, pkginfof)
@@ -36,7 +37,7 @@ def determineCramAppType():
                                     '--list',
                                     '--title', "Choose the type of software application",
                                     '--column="Type"', '--column="Description"']
-                                    + list(reduce(lambda x, y: x + y, appTypes.items()))
+                                    + list(reduce(lambda x, y: x + y, list(appTypes.items())))
                                     ).strip()
     return apptype
 
@@ -45,7 +46,7 @@ def getCramReleaseDir( url=None, refName=None ):
     packageInfoFile = '.cram/packageinfo'
     if url:
         if not refName:
-            print "getCramReleaseDir error: No refName for url", url
+            print("getCramReleaseDir error: No refName for url", url)
             return None
         packageInfoContent = gitGetRemoteFile( url, refName, packageInfoFile )
         if packageInfoContent:

--- a/cvs2git_utils.py
+++ b/cvs2git_utils.py
@@ -105,8 +105,8 @@ def importHistoryFromCVS(tpath, gitRepoPath, CVSpackageLocation ):
         # Create a bare git repo to load the CVS history into
         initBareRepo( gitRepoPath )
     except Exception as e:
-        print "importHistoryFromCVS Error: initBareRepo call failed!\ngitRepoPath = " + gitRepoPath 
-        print str(e)
+        print("importHistoryFromCVS Error: initBareRepo call failed!\ngitRepoPath = " + gitRepoPath) 
+        print(str(e))
         raise
 
     os.chdir(gitRepoPath)
@@ -116,7 +116,7 @@ def importHistoryFromCVS(tpath, gitRepoPath, CVSpackageLocation ):
     p2 = subprocess.Popen(['git', 'fast-import'], stdin=p1.stdout)
     p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
     p2.communicate()[0]
-    print "Done importing CVS dump into git repo"
+    print("Done importing CVS dump into git repo")
 
     # If cvs2git created a TAG.FIXUP branch, delete it
     cmdOutput = subprocess.check_output( [ 'git', 'branch', '-l' ] ).splitlines()
@@ -136,7 +136,7 @@ def checkCVS2GitPresent():
     
 def removeModuleFromCVS(tpath, packageName, CVSpackageLocation):
     '''Remove the package from the CVS modules file by checking out CVSROOT in the temporary folder tpath'''
-    print "Removing", packageName, "from CVS's module file."
+    print("Removing", packageName, "from CVS's module file.")
     curDir = os.getcwd()
     os.chdir(tpath)
     subprocess.check_call(['cvs', 'checkout', 'CVSROOT'])
@@ -145,9 +145,9 @@ def removeModuleFromCVS(tpath, packageName, CVSpackageLocation):
     for line in fileinput.input("modules", inplace=True):
         line=line.strip()
         if line.startswith(packageName):
-            print "# Commented out by eco %s" % (line)
+            print("# Commented out by eco %s" % (line))
         else:
-            print line
+            print(line)
 
     subprocess.check_call(['cvs', 'commit', '-m', 'eco commented out ' + packageName + ' as it was imported into git.'])
     
@@ -178,15 +178,15 @@ def importModuleType( cvsRoot, module, typePaths, gitFolder=None, repoPath=None,
         gitRepoPath = os.path.join( gitFolder, module + ".git" )
 
     if os.path.isdir( gitRepoPath ):
-        print "cvs import of repo already exists:", gitRepoPath
+        print("cvs import of repo already exists:", gitRepoPath)
         return
-    print "Importing CVS module %s from %s\n   to %s" % ( module, repoPath, gitRepoPath )
+    print("Importing CVS module %s from %s\n   to %s" % ( module, repoPath, gitRepoPath ))
  
     # Import the CVS history using a tmp folder
     tpath = tempfile.mkdtemp()
     try:
         importHistoryFromCVS( tpath, gitRepoPath, repoPath )
     except Exception as e:
-        print str(e)
+        print(str(e))
     shutil.rmtree(tpath)
-    print "CVS module %s successfully imported from %s\n   to %s" % ( module, repoPath, gitRepoPath )
+    print("CVS module %s successfully imported from %s\n   to %s" % ( module, repoPath, gitRepoPath ))

--- a/cvsModuleToGit.py
+++ b/cvsModuleToGit.py
@@ -44,5 +44,5 @@ if __name__ == '__main__':
         typePaths = moduleTypePaths[moduleType]
         cvs2git_utils.importModuleType( cvsRoot, m, typePaths, repoPath=args.repoPath, gitFolder=args.gitFolder )
 
-    print "Done."
+    print("Done.")
 

--- a/cvsModuleToGit.py
+++ b/cvsModuleToGit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script import an LCLS EPICS module from CVS to a git repo.'''
 
 import argparse

--- a/cvsRepo.py
+++ b/cvsRepo.py
@@ -39,7 +39,7 @@ class cvsRepo( Repo.Repo ):
         (repo_url, repo_tag) = (None, None)
         (packagePath, sep, packageName) = packageSpec.rpartition('/')
 
-        print "FindPackageRelease STUBBED: Need to find packagePath=%s, packageName=%s\n" % (packagePath, packageName)
+        print("FindPackageRelease STUBBED: Need to find packagePath=%s, packageName=%s\n" % (packagePath, packageName))
         return (repo_url, repo_tag)
 
     def GetDefaultPackage( self, package, verbose=False ):
@@ -50,7 +50,7 @@ class cvsRepo( Repo.Repo ):
         defaultPackage	= None
         ( cvs_url, cvs_branch, cvs_tag ) = cvsGetWorkingBranch()
         if not cvs_url:
-            print "Current directory is not an cvs working dir!"
+            print("Current directory is not an cvs working dir!")
             return None
 
         branchHead	= cvs_url
@@ -61,36 +61,36 @@ class cvsRepo( Repo.Repo ):
         else:
             defaultPackage = os.path.join( branchTail, defaultPackage )
         if verbose:
-            print "package:        ", package
-            print "defaultPackage: ", defaultPackage
-            print "self._branch:   ", self._branch
-            print "self._url:      ", self._url
-            print "cvs_url:        ", cvs_url
+            print("package:        ", package)
+            print("defaultPackage: ", defaultPackage)
+            print("self._branch:   ", self._branch)
+            print("self._url:      ", self._url)
+            print("cvs_url:        ", cvs_url)
         return defaultPackage
 
     def CheckoutRelease( self, buildDir, verbose=False, dryRun=False ):
         if verbose or dryRun:
-            print "Checking out: %s\nto build dir: %s ..." % ( self._url, buildDir )
+            print("Checking out: %s\nto build dir: %s ..." % ( self._url, buildDir ))
         outputPipe = None
         if verbose:
             outputPipe = subprocess.PIPE
         if dryRun:
-            print "CheckoutRelease: --dryRun--"
+            print("CheckoutRelease: --dryRun--")
             return
         try:
             cmdList = [ "cvs", "co", self._url, buildDir ]
             subprocess.check_call( cmdList, stdout=outputPipe, stderr=outputPipe )
         except RuntimeError:
-            raise Releaser.BuildError, "CheckoutRelease: cvs co failed for %s %s" % ( self._url, buildDir )
+            raise Releaser.BuildError("CheckoutRelease: cvs co failed for %s %s" % ( self._url, buildDir ))
 
     def RemoveTag( self, dryRun=True ):
-        print "RemoveTag: Removing %s release tag %s ..." % ( self._package[0], self._tag )
+        print("RemoveTag: Removing %s release tag %s ..." % ( self._package[0], self._tag ))
         if dryRun:
-            print "RemoveTag: --dryRun--"
+            print("RemoveTag: --dryRun--")
             return
         cmdList = [ "cvs", "tag", "-d", self._tag ]
         subprocess.check_call( cmdList )
-        print "Successfully removed release tag %s." % ( self._tag )
+        print("Successfully removed release tag %s." % ( self._tag ))
 
     def TagRelease( self, package=None, release=None, branch=None, message="", verbose=True, dryRun=False ):
         if branch is None:
@@ -98,9 +98,9 @@ class cvsRepo( Repo.Repo ):
         if release is None:
             release = self._repo._tag
         if dryRun:
-            print "--dryRun--",
+            print("--dryRun--", end=' ')
         if verbose:
-            print "Tagging branch %s release %s ..." % ( branch, release )
+            print("Tagging branch %s release %s ..." % ( branch, release ))
         if dryRun:
             return
 

--- a/cvsSpearModuleToGit.py
+++ b/cvsSpearModuleToGit.py
@@ -41,5 +41,5 @@ if __name__ == '__main__':
         typePaths = moduleTypePaths[moduleType]
         cvs2git_utils.importModuleType( cvsRoot, m, typePaths, repoPath=args.repoPath, gitFolder=args.gitFolder, fromDir='from-spear' )
 
-    print "Done."
+    print("Done.")
 

--- a/cvsSpearModuleToGit.py
+++ b/cvsSpearModuleToGit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script import an LCLS EPICS module from CVS to a git repo.'''
 
 import argparse

--- a/cvsToGit.py
+++ b/cvsToGit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script import a PCDS EPICS IOC from svn to a git repo.'''
 import sys
 import argparse

--- a/cvsToGit.py
+++ b/cvsToGit.py
@@ -22,7 +22,7 @@ def importCVS( gitRepoPath, packageName ):
         packageLocation = os.path.join(os.environ['CVSROOT'], cvs_modules2Location[packageName])
     else:
         packageLocation = os.path.join(os.environ['CVSROOT'], packageName)
-    print "Importing CVS package from ", packageLocation
+    print("Importing CVS package from ", packageLocation)
     gitRepoPath = importHistoryFromCVS( tmpPath, gitRepoPath, packageLocation )
     return gitRepoPath
 
@@ -43,7 +43,7 @@ Additional paths for both branches and tags may be added if desired either way.
     args = parser.parse_args( )
 
     if args.cvsPkg and args.trunk:
-        print 'Please specify either a CVS package specification or a trunk path, not both.'    
+        print('Please specify either a CVS package specification or a trunk path, not both.')    
         sys.exit()
 
     if args.filename:
@@ -60,11 +60,11 @@ Additional paths for both branches and tags may be added if desired either way.
                     continue
                 gitUrl = os.path.join( gitEpicsRoot, cvsPkg + '.git' )
                 if os.path.isdir( gitUrl ):
-                    print( "%s: Already imported" % cvsPkg )
+                    print(( "%s: Already imported" % cvsPkg ))
                     continue
                 importCVS( gitUrl, cvsPkg )
         except Exception as e:
-            print( "Error opening %s: %s" % ( args.filename, e ) )
+            print(( "Error opening %s: %s" % ( args.filename, e ) ))
     elif args.cvsPkg:
         gitUrl = args.URL
         # name=args.name, trunk=args.trunk, branches=args.branches, tags=args.tags, gitUrl=args.URL, verbose=args.verbose 
@@ -78,8 +78,8 @@ Additional paths for both branches and tags may be added if desired either way.
 #		importTrunk( args.trunk, args.name, args.URL, args.branches[1:], args.tags, args.verbose )
     else:
         parser.print_help()
-        print 'Please provide a cvsPkg name, or one or more branches to import'
+        print('Please provide a cvsPkg name, or one or more branches to import')
         sys.exit() 
 
-    print "Done."
+    print("Done.")
 

--- a/cvs_utils.py
+++ b/cvs_utils.py
@@ -15,7 +15,7 @@ def cvsPathExists( cvsPath, revision=None, debug=False ):
         else:
             repoCmd = [ 'cvs', 'ls', cvsPath ]
         if debug:
-            print "cvsPathExists check_output: %s" % ' '.join( repoCmd )
+            print("cvsPathExists check_output: %s" % ' '.join( repoCmd ))
         contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT )
         # No need to check contents
         # If no exception, the path exists
@@ -40,7 +40,7 @@ def cvsGetRemoteTags( packageName, verbose=False ):
         plaintags.add(parts[0].split(":")[0])
     tags = sorted(plaintags)
     if verbose:
-        print "cvsGetRemoteTags: Found %d tags in %s" % ( len(tags), packageName )
+        print("cvsGetRemoteTags: Found %d tags in %s" % ( len(tags), packageName ))
     return tags
 
 def cvsGetWorkingBranch( debug=False ):
@@ -70,26 +70,26 @@ def cvsGetWorkingBranch( debug=False ):
                         break
                 break
 
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     return ( repo_url, repo_branch, repo_tag )
 
 def cvsFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
     (repo_url, repo_path, repo_tag) = (None, None, None)
     if verbose:
-        print "cvsFindPackageRelease: Need to find packageSpec=%s, tag=%s" % (packageSpec, tag)
+        print("cvsFindPackageRelease: Need to find packageSpec=%s, tag=%s" % (packageSpec, tag))
 
     if verbose:
         if repo_url:
-            print "cvsFindPackageRelease found %s/%s: url=%s, repo_path=%s, tag=%s" % (packageSpec, tag, repo_url, repo_path, repo_tag)
+            print("cvsFindPackageRelease found %s/%s: url=%s, repo_path=%s, tag=%s" % (packageSpec, tag, repo_url, repo_path, repo_tag))
         else:
-            print "cvsFindPackageRelease Error: Cannot find %s/%s" % (packageSpec, tag)
+            print("cvsFindPackageRelease Error: Cannot find %s/%s" % (packageSpec, tag))
     return (repo_url, repo_path, repo_tag)
 
 
@@ -106,7 +106,7 @@ def parseCVSModulesTxt( cvsRepoRoot=None, verbose=False ):
     cvsModulesTxtFile = os.path.join( os.environ['CVSROOT'], 'CVSROOT', 'modules')
     if not os.path.exists(cvsModulesTxtFile):
         if verbose:
-            print "CVS modules file not accessible: Unable to load CVS module list."
+            print("CVS modules file not accessible: Unable to load CVS module list.")
         return package2Location
     
     with open(cvsModulesTxtFile, 'r') as f:
@@ -151,7 +151,7 @@ def parseCVSModulesTxt( cvsRepoRoot=None, verbose=False ):
         parts = line.split()
         if(len(parts) < 2):
             if verbose:
-                print "Error parsing ", cvsModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs"
+                print("Error parsing ", cvsModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs")
             continue
 
         packageName = parts[0]

--- a/eco_version.py
+++ b/eco_version.py
@@ -1,2 +1,2 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 eco_tools_version = "eco_tools R2.35"

--- a/epics-build.py
+++ b/epics-build.py
@@ -40,7 +40,7 @@ def build_modules( options ):
     status = 0
     if options.top:
         if not os.path.isdir( options.top ):
-            print "Invalid --top %s" % options.top
+            print("Invalid --top %s" % options.top)
     try:
         releases = find_releases( options )
         if len(releases) == 0:
@@ -51,8 +51,8 @@ def build_modules( options ):
                 if status == 0:
                     status = result
     except:
-        print sys.exc_value
-        print 'build_modules: Not all packages were installed!'
+        print(sys.exc_info()[1])
+        print('build_modules: Not all packages were installed!')
         return 1
     return status
  
@@ -61,7 +61,7 @@ def find_releases( options ):
     for package in options.packages:
         release = Releaser.find_release( package, verbose=options.verbose )
         if release is None:
-            print "Error: Could not find packageSpec: %s" % package
+            print("Error: Could not find packageSpec: %s" % package)
         else:
             releases += [ release ]
     return releases
@@ -69,7 +69,7 @@ def find_releases( options ):
 def buildDependencies( pkgTop, verbose=False ):
     status = 0
     # Check Dependendents
-    print "Checking dependents for %s" % ( pkgTop )
+    print("Checking dependents for %s" % ( pkgTop ))
     buildDep = getEpicsPkgDependents( pkgTop )
     for dep in buildDep:
         if dep == 'base':
@@ -77,7 +77,7 @@ def buildDependencies( pkgTop, verbose=False ):
         package = "%s/%s" % ( dep, buildDep[dep] )
         release = Releaser.find_release( package, verbose=verbose )
         if release is None:
-            print "Error: Could not find package %s" % package
+            print("Error: Could not find package %s" % package)
             continue
         result = release.InstallPackage( )
         if result != 0:
@@ -123,7 +123,7 @@ def main(argv=None):
     if (options.input_file_path):
         try:
             in_file = open(options.input_file_path, 'r')
-        except IOError, e:
+        except IOError as e:
             sys.stderr.write('Could not open "%s": %s\n' % (options.input_file_path, e.strerror))
             return None
 
@@ -138,7 +138,7 @@ def main(argv=None):
             if module and release:
                 options.packages += [ modulePath ]
                 if options.verbose:
-                    print 'Adding: %s' % modulePath
+                    print('Adding: %s' % modulePath)
 
             # repeat above for all lines in file
 
@@ -149,7 +149,7 @@ def main(argv=None):
         if result != 0:
             return  
     elif len( options.packages ) == 0:
-        print 'Error: No module/release packages specified!'
+        print('Error: No module/release packages specified!')
         return  
 
     return build_modules( options )

--- a/epics-build.py
+++ b/epics-build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Name: epics-build.py
 #  Abs:  A tool to build one or more EPICS releases
 #

--- a/epics-checkout.py
+++ b/epics-checkout.py
@@ -76,7 +76,7 @@ def assemble_env_inputs_from_term(options):
         packageSpec = options.module
         packageName = os.path.split(packageSpec)[1]
 
-    packageNames = set().union(git_package2Location.keys(), cvs_modules2Location.keys())
+    packageNames = set().union(list(git_package2Location.keys()), list(cvs_modules2Location.keys()))
 
     def packageNameCompleter(text, state):
         options = [x for x in packageNames if x.startswith(text)]
@@ -89,7 +89,7 @@ def assemble_env_inputs_from_term(options):
     readline.parse_and_bind("tab: complete")
 
     while not packageName:
-        packageSpec = raw_input('Enter name of module/package to checkout: ').strip()
+        packageSpec = input('Enter name of module/package to checkout: ').strip()
         packageName = os.path.split(packageSpec)[1]
 
     # Remove completer after we are done...
@@ -141,7 +141,7 @@ def assemble_env_inputs_from_term(options):
 
         if not options.batch:
             prompt1 = 'Enter name of tag or [RETURN] to create a sandbox named %s>' % dirName
-            tagName = raw_input(prompt1).strip()
+            tagName = input(prompt1).strip()
 
         readline.set_completer()
         readline.parse_and_bind('tab: self-insert')
@@ -224,25 +224,25 @@ def checkOutModule(packageSpec, repoPath, tag, destinationPath, options, from_fi
 
     packageName = os.path.split(packageSpec)[1]
     if tag == '':
-        print "Checkout %s to sandbox directory %s" % ( packageName, destinationPath )
+        print("Checkout %s to sandbox directory %s" % ( packageName, destinationPath ))
     else:
-        print "Checkout %s, tag %s, to directory %s" % ( packageName, tag, destinationPath )
+        print("Checkout %s, tag %s, to directory %s" % ( packageName, tag, destinationPath ))
     if not options.batch:
-        confirmResp = raw_input( 'Proceed (Y/n)?' )
+        confirmResp = input( 'Proceed (Y/n)?' )
         if len(confirmResp) != 0 and confirmResp != "Y" and confirmResp != "y":
-            print "Aborting....."
+            print("Aborting.....")
             sys.exit(0)
 
     # TODO: Can we update existing dir using repo?
     if os.path.exists(destinationPath):
-        print 'Directory already exists!  Aborting.....'
+        print('Directory already exists!  Aborting.....')
         sys.exit(1)
 
     parent_dir = os.path.dirname( destinationPath )
     if len(parent_dir) > 0 and parent_dir != '.' and not os.path.exists(parent_dir):
         try:
-            os.makedirs(parent_dir, 0775)
-        except OSError, e:
+            os.makedirs(parent_dir, 0o775)
+        except OSError as e:
             sys.stderr.write( 'Unable to create directory: %s\n' % parent_dir )
             sys.exit(1)
 
@@ -258,17 +258,17 @@ def checkOutModule(packageSpec, repoPath, tag, destinationPath, options, from_fi
         # See if we can find it in with the git repos
         repoPath = determinePathToGitRepo(packageSpec)
     if not repoPath:
-        print "Unable to determine repo path for %s" % packageSpec
+        print("Unable to determine repo path for %s" % packageSpec)
         return
 
     if "git" not in repoPath and "svn" not in repoPath and cvs_modules2Location is not None:
         # Do CVS checkout
         if (tag == 'MAIN_TRUNK'):
             cmd='cvs checkout -P -d ' + destinationPath + ' ' + packageSpec    
-            print cmd
+            print(cmd)
         else:
             cmd='cvs checkout -P -r '+ tag +' -d '+ destinationPath +' ' + packageSpec    
-            print cmd
+            print(cmd)
         os.system(cmd)
         if not os.path.isdir(destinationPath):
             sys.stderr.write( "Error: unable to do cvs checkout of %s\n" % packageSpec )
@@ -289,17 +289,17 @@ def checkOutModule(packageSpec, repoPath, tag, destinationPath, options, from_fi
                 pathToSvnRepo = pathToSvnRepo.replace( "trunk","tags" )
                 pathToSvnRepo = pathToSvnRepo.replace( "current",tag )
             cmd=[ 'svn', 'checkout', pathToSvnRepo, destinationPath ]
-            print cmd
+            print(cmd)
             subprocess.check_call(cmd)
             if not os.path.isdir(destinationPath):
                 sys.stderr.write( "Error: unable to do svn checkout of %s\n" % packageName )
                 sys.exit(1)
             os.chdir(destinationPath)
         else:
-            print packageName, "is a git package.\nCloning the repository at", repoPath
+            print(packageName, "is a git package.\nCloning the repository at", repoPath)
             if os.path.exists(destinationPath):
-                print "The folder", os.path.abspath(destinationPath), "already exists. If you intended to update the checkout, please do a git pull to pull in the latest changes."
-                print "Aborting....."
+                print("The folder", os.path.abspath(destinationPath), "already exists. If you intended to update the checkout, please do a git pull to pull in the latest changes.")
+                print("Aborting.....")
                 sys.exit(1)
             # TODO: Verify the tag exists before we clone the repo for better user error msg and to avoid broken release dirs
             branch = None
@@ -313,7 +313,7 @@ def checkOutModule(packageSpec, repoPath, tag, destinationPath, options, from_fi
             if (tag != ''):
                 # Do a headless checkout to the specified tag
                 cmd=['git', 'checkout', tag]
-                print cmd
+                print(cmd)
                 subprocess.check_call(cmd)
             #else: TODO Checkout a default branch if one isn't already selected.
             # 1. current release branch
@@ -381,7 +381,7 @@ def initGitBareRepo( options ):
     elif packageName in cvs_modules2Location:
         packageLocation = os.path.join(os.environ['CVSROOT'], cvs_modules2Location[packageName])
     if packageLocation:
-        print "Error: The package " + packageSpec + " is already registered and exists in:\n" + packageLocation
+        print("Error: The package " + packageSpec + " is already registered and exists in:\n" + packageLocation)
         if showStatusZenity:
             subprocess.check_call(["zenity", "--error", "--title", "Error", "--text", "The package " + packageName + " is already registered and exists in " + packageLocation])
         return
@@ -399,8 +399,8 @@ def initGitBareRepo( options ):
         # Create the upstream repo as a bare repo
         initBareRepo( gitRepoPath )
     except Exception as e:
-        print "initGitBareRepo Error: initBareRepo call failed!\ngitRepoPath = " + gitRepoPath 
-        print str(e)
+        print("initGitBareRepo Error: initBareRepo call failed!\ngitRepoPath = " + gitRepoPath) 
+        print(str(e))
         return
 
     tpath = tempfile.mkdtemp()
@@ -424,7 +424,7 @@ def initGitBareRepo( options ):
     
     addPackageToEcoModuleList(packageSpec, gitRepoPath)
     
-    print "Done creating bare repo for package ", packageSpec, ". Use eco to clone this repo into your working directory."
+    print("Done creating bare repo for package ", packageSpec, ". Use eco to clone this repo into your working directory.")
     if showStatusZenity:
         subprocess.check_call(	["zenity", "--info", "--title", "Repo created for " + packageSpec,
                                 "--text", "Done creating bare repo for package " + packageSpec +
@@ -445,17 +445,17 @@ def importFromCVS( options ):
                                                 "Please enter the name of the package"] ).strip()
 
     if packageName in git_package2Location:
-        print "eco cvs2git error: %s is already registered and exists here:\n%s" % ( packageName, git_package2Location[packageName] )
+        print("eco cvs2git error: %s is already registered and exists here:\n%s" % ( packageName, git_package2Location[packageName] ))
         return
     if packageName not in cvs_modules2Location:
-        print "eco cvs2git error: %s does not seem to be a CVS module." % packageName
-        print "Make sure it exists in %s/CVSROOT/modules" % os.environ['CVSROOT']
+        print("eco cvs2git error: %s does not seem to be a CVS module." % packageName)
+        print("Make sure it exists in %s/CVSROOT/modules" % os.environ['CVSROOT'])
         return
 
     if 'CVSROOT' not in os.environ:
         os.environ['CVSROOT'] = DEF_CVS_ROOT
     CVSpackageLocation = os.path.join(os.environ['CVSROOT'], cvs_modules2Location[packageName])
-    print "Importing CVS package from ", CVSpackageLocation
+    print("Importing CVS package from ", CVSpackageLocation)
 
     if options.destination:
         bareRepoParentFolder = options.destination
@@ -476,10 +476,10 @@ def importFromCVS( options ):
     try:
         cvs2git_utils.importHistoryFromCVS(tpath, gitRepoPath, CVSpackageLocation)
     except Exception as e:
-        print str(e)
+        print(str(e))
         return
 
-    print "CVS history for ", packageName, " imported to ", gitRepoPath
+    print("CVS history for ", packageName, " imported to ", gitRepoPath)
 
     # Add .gitignore
     clonedFolder = cloneUpstreamRepo(gitRepoPath, tpath, packageName)
@@ -497,7 +497,7 @@ def importFromCVS( options ):
     os.chdir(curDir)
     shutil.rmtree(tpath)
 
-    print "Done creating bare repo for package ", packageName, ". Use eco to clone this repo into your working directory."
+    print("Done creating bare repo for package ", packageName, ". Use eco to clone this repo into your working directory.")
     if showStatusZenity:
         subprocess.check_call(	["zenity", "--info", "--title", "Repo created for " + packageName,
                                 "--text", "Done creating bare repo for package " + packageName +
@@ -505,10 +505,10 @@ def importFromCVS( options ):
 
 
 def module_callback(option, opt_str, value, parser):
-    print 'Processing MODULE option; Setting', option.dest, 'to', value
+    print('Processing MODULE option; Setting', option.dest, 'to', value)
     setattr(parser.values, option.dest, value)
     if len(parser.rargs) > 0 and not parser.rargs[0].startswith("-"):
-        print 'Setting tag to ' + parser.rargs[0]
+        print('Setting tag to ' + parser.rargs[0])
         setattr(parser.values, 'tag', parser.rargs[0])
         parser.rargs.pop(0)
 
@@ -575,7 +575,7 @@ def main(argv=None):
             return
         try:
             in_file = open(options.input_file_path, 'r')
-        except IOError, e:
+        except IOError as e:
             sys.stderr.write('Could not open module specification file "%s": %s\n' % (options.input_file_path, e.strerror))
             return None
 
@@ -589,12 +589,12 @@ def main(argv=None):
             key = key.strip()
             value = value.strip()
 
-            print 'key is: ' + key
-            print 'value is: ' + value
+            print('key is: ' + key)
+            print('value is: ' + value)
 
             assemble_env_inputs_from_file(key,value,options)
            
-            print 'done with ' + line
+            print('done with ' + line)
             # repeat above for all lines in file
 
         in_file.close()

--- a/epics-checkout.py
+++ b/epics-checkout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #==============================================================
 #
 #  Abs:  A tool to checkout an EPICS package

--- a/epics-jenkins.py
+++ b/epics-jenkins.py
@@ -46,7 +46,7 @@ def build_modules( options ):
     status = 0
     if options.top:
         if not os.path.isdir( options.top ):
-            print "Invalid --top %s" % options.top
+            print("Invalid --top %s" % options.top)
     try:
         releases = find_releases( options )
         if len(releases) == 0:
@@ -57,8 +57,8 @@ def build_modules( options ):
                 if status == 0:
                     status = result
     except:
-        print sys.exc_value
-        print 'build_modules: Not all packages were installed!'
+        print(sys.exc_info()[1])
+        print('build_modules: Not all packages were installed!')
         return 1
     return status
  
@@ -67,7 +67,7 @@ def find_releases( options ):
     for package in options.packages:
         release = Releaser.find_release( package, verbose=options.verbose )
         if release is None:
-            print "Error: Could not find packageSpec: %s" % package
+            print("Error: Could not find packageSpec: %s" % package)
         else:
             releases += [ release ]
     return releases
@@ -75,7 +75,7 @@ def find_releases( options ):
 def buildDependencies( pkgTop, verbose=False ):
     status = 0
     # Check Dependendents
-    print "Checking dependents for %s" % ( pkgTop )
+    print("Checking dependents for %s" % ( pkgTop ))
     buildDep = getEpicsPkgDependents( pkgTop )
     for dep in buildDep:
         if dep == 'base':
@@ -83,7 +83,7 @@ def buildDependencies( pkgTop, verbose=False ):
         package = "%s/%s" % ( dep, buildDep[dep] )
         release = Releaser.find_release( package, verbose=verbose )
         if release is None:
-            print "Error: Could not find package %s" % package
+            print("Error: Could not find package %s" % package)
             continue
         result = release.InstallPackage( )
         if result != 0:
@@ -131,7 +131,7 @@ def main(argv=None):
     if (options.input_file_path):
         try:
             in_file = open(options.input_file_path, 'r')
-        except IOError, e:
+        except IOError as e:
             sys.stderr.write('Could not open "%s": %s\n' % (options.input_file_path, e.strerror))
             return None
 
@@ -146,32 +146,32 @@ def main(argv=None):
             if module and release:
                 options.packages += [ modulePath ]
                 if options.verbose:
-                    print 'Adding: %s' % modulePath
+                    print('Adding: %s' % modulePath)
 
             # repeat above for all lines in file
 
         in_file.close()
 
     if options.commit:
-        print 'epics-jenkins: commit to build %s' % options.commit
+        print('epics-jenkins: commit to build %s' % options.commit)
         if options.commit == options.priorCommit:
-            print 'epics-jenkins: No change, nothing to build.'
+            print('epics-jenkins: No change, nothing to build.')
             return 0
 
     if options.priorCommit:
-        print 'epics-jenkins: priorCommit to build %s' % options.priorCommit
+        print('epics-jenkins: priorCommit to build %s' % options.priorCommit)
 
     if options.dep:
         result = buildDependencies( options.dep, verbose=options.verbose )
         if result != 0:
             return 0  
     elif len( options.packages ) == 0:
-        print 'Error: No module/release packages specified!'
+        print('Error: No module/release packages specified!')
         return 0
 
     status = build_modules( options )
     if status:
-        print 'epics-jenkins build error\n'
+        print('epics-jenkins build error\n')
     return 0
 
 if __name__ == '__main__':

--- a/epics-jenkins.py
+++ b/epics-jenkins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Name: epics-jenkins.py
 #  Abs:  A tool to handle jenkins SCM polling jobs.
 #

--- a/epics-release.py
+++ b/epics-release.py
@@ -4,15 +4,15 @@ import sys
 
 # Check the python version
 if sys.version_info[0] < 2 or ( sys.version_info[0] == 2 and sys.version_info[1] < 7 ):
-    print >> sys.stderr, "Python version %d.%d not supported." % (sys.version_info[0], sys.version_info[1])
-    print >> sys.stderr, "Please use python 2.7 or newer for epics-release."
+    print("Python version %d.%d not supported." % (sys.version_info[0], sys.version_info[1]), file=sys.stderr)
+    print("Please use python 2.7 or newer for epics-release.", file=sys.stderr)
     sys.exit(1)
 
 import shutil
 import optparse
 import traceback
 import tempfile
-import commands
+import subprocess
 import stat
 import os
 import subprocess
@@ -66,7 +66,7 @@ def ValidateArgs( repo, packageSpec, opt ):
     # release=None, message=None, verbose=False, batch=False )
     # validate the repo
     if not repo:
-        raise ValidateError, "Repo not found for packageSpec %s" % (packageSpec)
+        raise ValidateError("Repo not found for packageSpec %s" % (packageSpec))
     defaultPackage	= None
     ( repo_url, repo_branch, repo_tag ) = repo.GetWorkingBranch()
     if repo_url:
@@ -79,19 +79,19 @@ def ValidateArgs( repo, packageSpec, opt ):
             packageSpec = [ defaultPackage ]
 
     if opt.verbose:
-        print "epics-release ValidateArgs: repo_url       =", repo_url
-        print "epics-release ValidateArgs: repo_branch    =", repo_branch
-        print "epics-release ValidateArgs: repo_tag       =", repo_tag
-        print "epics-release ValidateArgs: packageSpec    =", packageSpec
-        print "epics-release ValidateArgs: defaultPackage =", defaultPackage
-        print "epics-release ValidateArgs: release        =", opt.release
+        print("epics-release ValidateArgs: repo_url       =", repo_url)
+        print("epics-release ValidateArgs: repo_branch    =", repo_branch)
+        print("epics-release ValidateArgs: repo_tag       =", repo_tag)
+        print("epics-release ValidateArgs: packageSpec    =", packageSpec)
+        print("epics-release ValidateArgs: defaultPackage =", defaultPackage)
+        print("epics-release ValidateArgs: release        =", opt.release)
 
     # Determine the release package URL
     if not repo_branch:
         if not packageSpec:
-            raise ValidateError, "No release package specified"
+            raise ValidateError("No release package specified")
         if packageSpec is list and len( packageSpec ) > 1:
-            raise ValidateError, "Multiple release packages specified: %s" % (packageSpec)
+            raise ValidateError("Multiple release packages specified: %s" % (packageSpec))
         if repo_url:
             repo_branch = repo_url
 
@@ -106,63 +106,63 @@ def ValidateArgs( repo, packageSpec, opt ):
         if repo_tag is not None:
             opt.release = repo_tag
     if opt.release is None:
-        raise ValidateError, "Release tag not specified (--release)"
+        raise ValidateError("Release tag not specified (--release)")
 
     if not re.match( r"(\S*R\d+([\-\.]\d+)-\d+\.\d+\.\d+?)|(\S*R\d+[\.\-]\d+([\-\.]\d+)?)", opt.release ):
-        raise ValidateError, "%s is an invalid release tag: Must be R[<orig_release>-]<major>.<minor>.<bugfix>" % opt.release
+        raise ValidateError("%s is an invalid release tag: Must be R[<orig_release>-]<major>.<minor>.<bugfix>" % opt.release)
 
     if not opt.noTag and repo_tag != opt.release:
         # validate release message
         if not opt.message:
-            print "Please enter a release comment (end w/ ctrl-d on blank line):"
+            print("Please enter a release comment (end w/ ctrl-d on blank line):")
             comment = ""
             try:
                 while True:
-                    line = raw_input()
+                    line = input()
                     comment = "\n".join( [ comment, line ] ) 
             except EOFError:
                 opt.message = comment
 
         if opt.message is None:
-            raise ValidateError, "Release message not specified (-m)"
+            raise ValidateError("Release message not specified (-m)")
 
     # if repo_url: This is an svn only test
     if False:
         # Check release branch vs working dir branch
         if repo_branch != repo_url:
-            print "Release branch: %s\nWorking branch: %s" % ( repo_branch, repo_url )
+            print("Release branch: %s\nWorking branch: %s" % ( repo_branch, repo_url ))
             if not opt.batch:
-                confirmResp = raw_input( 'Release branch does not match working dir.  Proceed (Y/n)?' )
+                confirmResp = input( 'Release branch does not match working dir.  Proceed (Y/n)?' )
                 if len(confirmResp) != 0 and confirmResp != "Y" and confirmResp != "y":
                     branchMsg = "Branch mismatch!\n"
-                    raise ValidateError, branchMsg
+                    raise ValidateError(branchMsg)
 
     versionFileName = git_get_versionFileName()
     if versionFileName and os.path.isfile( versionFileName ):
         # TODO: has it changed, show the change, prompt to edit
-        print "Did you remember to update the version file? %s" % versionFileName
+        print("Did you remember to update the version file? %s" % versionFileName)
 
     if os.path.isfile( "RELEASE_NOTES" ):
         # TODO: has it changed, is tag found, show the change
         # TODO: prompt to edit, pre-populate release entry
-        print "Did you remember to update the RELEASE_NOTES file?"
+        print("Did you remember to update the RELEASE_NOTES file?")
 
     # validate repo_grpowner	= DEF_LCLS_GROUP_OWNER
     if opt.verbose:
-        print "ValidateArgs: Success"
-        print "  repo_url:    %s" % repo_url
-        print "  branch:      %s" % repo_branch
-        print "  tag:         %s" % opt.release
+        print("ValidateArgs: Success")
+        print("  repo_url:    %s" % repo_url)
+        print("  branch:      %s" % repo_branch)
+        print("  tag:         %s" % opt.release)
         #print "  releasePath: %s" % repo_ReleasePath
         if opt.message:
-            print "  message: %s" % opt.message
+            print("  message: %s" % opt.message)
 
 # Entry point of the script. This is main()
 try:
     # Make sure we have a valid EPICS_SITE_TOP
     defaultEpicsSiteTop = determine_epics_site_top()
     if not defaultEpicsSiteTop or not os.path.isdir( defaultEpicsSiteTop ):
-        raise ValidateError, ( "Can't find EPICS_SITE_TOP at %s" % defaultEpicsSiteTop )
+        raise ValidateError( "Can't find EPICS_SITE_TOP at %s" % defaultEpicsSiteTop)
 
     parser = optparse.OptionParser(
         usage =	"usage: %prog [options] -r <release> [ <packageSpec> ] [ -m \"My release comments\" ]\n"
@@ -222,10 +222,10 @@ try:
     ( opt, args ) = parser.parse_args()
 
     if not opt.release:
-        raise ValidateError, ( "Release tag not specified!" )
+        raise ValidateError(( "Release tag not specified!" ))
 
     if opt.verbose:
-        print "epics-release main: opt.message=%s, args=%s" % ( opt.message, args )
+        print("epics-release main: opt.message=%s, args=%s" % ( opt.message, args ))
 
     repo         = None
     packageMatch = None
@@ -238,8 +238,8 @@ try:
 
     if git_url:
         if opt.verbose:
-            print "git_url:    %s" % git_url
-            print "git_branch: %s" % git_branch
+            print("git_url:    %s" % git_url)
+            print("git_branch: %s" % git_branch)
         # Create a git release handler
         ( urlPath, packageGitDir ) = os.path.split( git_url )
         if packageGitDir is None:
@@ -284,8 +284,8 @@ try:
             if opt.noTag:
                 svn_url	= "/".join( [ DEF_SVN_TAGS, packagePath, opt.release ] )
             if opt.verbose:
-                print "svn_url:    %s" % svn_url
-                print "svn_branch: %s" % svn_branch
+                print("svn_url:    %s" % svn_url)
+                print("svn_branch: %s" % svn_branch)
             # Create an svn release handler
             repo = svnRepo.svnRepo( svn_url, svn_branch, packagePath, opt.release )
 
@@ -296,22 +296,22 @@ try:
             if os.path.split(packageSpec)[1] != opt.release:
                 packageSpec = os.path.join( packageSpec, opt.release )
         if opt.verbose:
-            print "epics-release main: packageSpec=%s, args=%s" % ( packageSpec, args )
+            print("epics-release main: packageSpec=%s, args=%s" % ( packageSpec, args ))
         release = find_release( packageSpec, repo_url=repo.GetUrl(), verbose=opt.verbose )
         if release:
             if not release._packageName:
-                raise ValidateError, ( "Invalid package specified: %s" % packageSpec )
+                raise ValidateError( "Invalid package specified: %s" % packageSpec)
             repo = release._repo
             packageName = release._packageName
 
     if not packageName:
-        raise ValidateError, ( "No package specified and unable to determine it from current dir" )
+        raise ValidateError(( "No package specified and unable to determine it from current dir" ))
     elif opt.verbose:
-        print "package:    %s" % packageName
+        print("package:    %s" % packageName)
 
     # Have to have a repo to do a release
     if repo is None:
-        raise ValidateError, ( "Can't establish a repo branch" )
+        raise ValidateError(( "Can't establish a repo branch" ))
 
     pkgReleaser = Releaser( repo, packagePath, verbose=opt.verbose )
 
@@ -342,7 +342,7 @@ try:
         if releaseDir:
             opt.installDir = os.path.join(	releaseDir, opt.release	)
         if opt.installDir and opt.verbose:
-            print "CRAM releaseDir: %s" % releaseDir
+            print("CRAM releaseDir: %s" % releaseDir)
 
     if not opt.installDir:
         # See if we can derive the releaseDir from the packagePath
@@ -351,69 +351,69 @@ try:
         if 'base' in topDirDependents:
             epics_base_ver = topDirDependents['base']
             if strContainsMacros( epics_base_ver ):
-                raise ValidateError, "Unable to determine EPICS base version from RELEASE files"
+                raise ValidateError("Unable to determine EPICS base version from RELEASE files")
         if not packageName:
-            raise ValidateError, "No release package specified"
+            raise ValidateError("No release package specified")
         if os.path.split( packagePath )[0] == 'modules':
             if not epics_base_ver:
                 epics_base_ver = determine_epics_base_ver()
             if not epics_base_ver:
-                raise ValidateError, "Unable to determine EPICS base version"
+                raise ValidateError("Unable to determine EPICS base version")
             opt.installDir = os.path.join(	defaultEpicsSiteTop, epics_base_ver,
                                             packagePath, opt.release	)
         else:
             opt.installDir = os.path.join(	defaultEpicsSiteTop, packagePath, opt.release )
     pkgReleaser._installDir = opt.installDir
-    print     "repo_url:    %s" % repo.GetUrl()
+    print("repo_url:    %s" % repo.GetUrl())
     if opt.rmTag:
-        print "rm tag:      %s" % opt.release
+        print("rm tag:      %s" % opt.release)
     else:
-        print "tag:         %s" % opt.release 
+        print("tag:         %s" % opt.release) 
     if opt.rmBuild:
-        print "rm buildDir: %s"	% opt.installDir
+        print("rm buildDir: %s"	% opt.installDir)
     else:
-        print "installDir:  %s"	% opt.installDir
+        print("installDir:  %s"	% opt.installDir)
     if opt.dryRun:
-        print "DryRun:      True"
+        print("DryRun:      True")
     if	opt.noTag:
         opt.noTestBuild	= True
 
     if git_url:
         if opt.verbose and git_tag != opt.release:
-            print "Need to tag %s\n" % opt.release
+            print("Need to tag %s\n" % opt.release)
         # Make sure the tag has been pushed
         (remote_tag_sha, remote_tag ) = gitGetRemoteTag( git_url, opt.release )
         local_tag_sha = gitGetTagSha( opt.release )
         if remote_tag != opt.release or remote_tag_sha != local_tag_sha:
             if opt.verbose:
-                print "Need to push tag %s\n" % opt.release
+                print("Need to push tag %s\n" % opt.release)
 
     # Confirm buildDir, installDir, and tag
     if not opt.batch and not opt.dryRun:
-        confirmResp = raw_input( 'Proceed (Y/n)?' )
+        confirmResp = input( 'Proceed (Y/n)?' )
         if len(confirmResp) != 0 and confirmResp != "Y" and confirmResp != "y":
             sys.exit(0)
 
     # dryRun, just show release info
     if opt.dryRun:
-        print "--dryRun--"
+        print("--dryRun--")
         if opt.rmTag:
-            print "rm tag:      %s" % opt.release
+            print("rm tag:      %s" % opt.release)
         if opt.rmBuild:
-            print "rm buildDir: %s"	% opt.installDir
+            print("rm buildDir: %s"	% opt.installDir)
         if not opt.rmTag and not opt.rmBuild:
-            print "MakeRelease: %s" % opt.release
-            print "branch:      %s" % repo._branch
-            print "installDir:  %s" % opt.installDir
-            print "message:     %s" % opt.message
+            print("MakeRelease: %s" % opt.release)
+            print("branch:      %s" % repo._branch)
+            print("installDir:  %s" % opt.installDir)
+            print("message:     %s" % opt.message)
         sys.exit(0)
 
     if opt.rmBuild or opt.rmTag:
         if opt.rmBuild:
             try:
                 pkgReleaser.RemoveBuild( opt.installDir )
-            except BuildError, e:
-                print e
+            except BuildError as e:
+                print(e)
                 pass
         if opt.rmTag:
             pkgReleaser.RemoveTag( tag=opt.release )
@@ -452,29 +452,29 @@ try:
     sys.exit(0)
 
 except ValidateError:
-    print "Error: %s\n" % sys.exc_value 
+    print("Error: %s\n" % sys.exc_info()[1]) 
     parser.print_usage()
     sys.exit(6)
 
 except BuildError:
-    print "\nError: BUILD FAILURE"
-    print "%s\n" % sys.exc_value 
-    print "Fix build problems and commit any necessary changes"
+    print("\nError: BUILD FAILURE")
+    print("%s\n" % sys.exc_info()[1]) 
+    print("Fix build problems and commit any necessary changes")
     sys.exit(5)
 
 except svnError:
-    print "\nsvn FAILURE"
-    print "%s\n" % sys.exc_value 
-    print "Please copy script output and notify someone appropriate"
+    print("\nsvn FAILURE")
+    print("%s\n" % sys.exc_info()[1]) 
+    print("Please copy script output and notify someone appropriate")
     sys.exit(4)
 
 except InstallError:
-    print "\nERROR: INSTALL FAILURE"
-    print "%s\n" % sys.exc_value 
+    print("\nERROR: INSTALL FAILURE")
+    print("%s\n" % sys.exc_info()[1]) 
     sys.exit(3)
 
 except KeyboardInterrupt:
-    print "\nERROR: interrupted by user."
+    print("\nERROR: interrupted by user.")
     sys.exit(2)
 
 except SystemExit:
@@ -482,6 +482,6 @@ except SystemExit:
 
 except:
     if debugScript:
-        traceback.print_tb(sys.exc_traceback)
-    print "%s exited with ERROR:\n%s\n" % ( sys.argv[0], sys.exc_value )
+        traceback.print_tb(sys.exc_info()[2])
+    print("%s exited with ERROR:\n%s\n" % ( sys.argv[0], sys.exc_info()[1] ))
     sys.exit( 1 )

--- a/epics-release.py
+++ b/epics-release.py
@@ -222,7 +222,7 @@ try:
     ( opt, args ) = parser.parse_args()
 
     if not opt.release:
-        raise ValidateError(( "Release tag not specified!" ))
+        raise ValidateError( "Release tag not specified!" )
 
     if opt.verbose:
         print("epics-release main: opt.message=%s, args=%s" % ( opt.message, args ))
@@ -305,13 +305,13 @@ try:
             packageName = release._packageName
 
     if not packageName:
-        raise ValidateError(( "No package specified and unable to determine it from current dir" ))
+        raise ValidateError( "No package specified and unable to determine it from current dir" )
     elif opt.verbose:
         print("package:    %s" % packageName)
 
     # Have to have a repo to do a release
     if repo is None:
-        raise ValidateError(( "Can't establish a repo branch" ))
+        raise ValidateError( "Can't establish a repo branch" )
 
     pkgReleaser = Releaser( repo, packagePath, verbose=opt.verbose )
 

--- a/epics-release.py
+++ b/epics-release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import re
 import sys
 

--- a/epics-update.py
+++ b/epics-update.py
@@ -64,9 +64,9 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
             if macroName in newMacroVersions:
                 newVersion = newMacroVersions[macroName]
                 if newVersion != oldVersion:
-                    print "Old: %s" %  line,
+                    print("Old: %s" %  line, end=' ')
                     line = string.replace( line, oldVersion, newMacroVersions[macroName] )
-                    print "New: %s" %  line,
+                    print("New: %s" %  line, end=' ')
                     modified = True
 
                 if macroName == "BASE":
@@ -114,22 +114,22 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
                 # We've already defined this macroName
                 if not commentedOut:
                     # Comment out subsequent definitions
-                    print "Old: %s" %  line,
+                    print("Old: %s" %  line, end=' ')
                     line = string.replace( line, originalLine, '#' + originalLine )
-                    print "New: %s" %  line,
+                    print("New: %s" %  line, end=' ')
                     modified = True
             else:
                 definedModules[macroName] = newVersionPath
                 if commentedOut:
                     # Uncomment the line
-                    print "Old: %s" %  line,
+                    print("Old: %s" %  line, end=' ')
                     line = string.strip( line, '# ' )
-                    print "New: %s" %  line,
+                    print("New: %s" %  line, end=' ')
                     modified = True
                 if oldVersionPath != newVersionPath:
-                    print "Old: %s" %  line,
+                    print("Old: %s" %  line, end=' ')
                     line = string.replace( line, oldVersionPath, newVersionPath )
-                    print "New: %s" %  line,
+                    print("New: %s" %  line, end=' ')
                     modified = True
 
         if not "BASE" in newMacroVersions:
@@ -158,8 +158,8 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
             oldLine = line
             line = string.replace( line, oldBaseVersion, newBaseVersion )
             if newBaseVersion in line:
-                print "Old: %s" %  oldLine,
-                print "New: %s" %  line,
+                print("Old: %s" %  oldLine, end=' ')
+                print("New: %s" %  line, end=' ')
                 modified = True
                 lineCache += line
                 continue
@@ -175,8 +175,8 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
             #line = string.replace( line, oldBaseVersion, newBaseVersion )
             #line = string.replace( line, oldVersionPath, baseDirName )
             if True or newBaseVersion in line:
-                print "Old: %s" %  oldLine,
-                print "New: %s" %  line,
+                print("Old: %s" %  oldLine, end=' ')
+                print("New: %s" %  line, end=' ')
             modified = True
 
         if macroName == "EPICS_BASE":
@@ -187,9 +187,9 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
             else:
                 newVersionPath = "$(EPICS_SITE_TOP)/base/%s" % baseDirName 
             if oldVersionPath != newVersionPath:
-                print "Old: %s" %  line,
+                print("Old: %s" %  line, end=' ')
                 line = string.replace( line, oldVersionPath, newVersionPath )
-                print "New: %s" %  line,
+                print("New: %s" %  line, end=' ')
                 modified = True
 
         if macroName == "EPICS_MODULES" or macroName == "MODULES_SITE_TOP":
@@ -198,9 +198,9 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
             else:
                 newVersionPath = "$(EPICS_SITE_TOP)/%s/modules" % newBaseVersion
             if oldVersionPath != newVersionPath:
-                print "Old: %s" %  line,
+                print("Old: %s" %  line, end=' ')
                 line = string.replace( line, oldVersionPath, newVersionPath )
-                print "New: %s" %  line,
+                print("New: %s" %  line, end=' ')
                 modified = True
 
         lineCache += line
@@ -209,7 +209,7 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
     in_file.close()
     if not modified:
         if verbose:
-            print("%s, No change" %  filePath)
+            print(("%s, No change" %  filePath))
         return 0
 
     # Replace prior version w/ updates
@@ -224,7 +224,7 @@ def update_pkg_dep_file( filePath, oldMacroVersions, newMacroVersions, verbose=F
     except IOError as e:
         sys.stderr.write( 'Could not replace "%s": %s\n' % ( filePath, e.strerror ) )
         return 0
-    print("%s, UPDATED" %  filePath)
+    print(("%s, UPDATED" %  filePath))
     return 1
 
 def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
@@ -242,10 +242,10 @@ def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
     """
     # Check for a valid top directory
     if not os.path.isdir( topDir ):
-        print("update_pkg_dependency: Invalid topDir: %s" % topDir)
+        print(("update_pkg_dependency: Invalid topDir: %s" % topDir))
         return 0
     if verbose:
-        print("update_pkg_dependency: %s" % topDir)
+        print(("update_pkg_dependency: %s" % topDir))
 
     # Get current pkgSpecs
     oldPkgDependents = getEpicsPkgDependents( topDir, debug=debug )
@@ -253,10 +253,10 @@ def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
     for pkgName in oldPkgDependents:
         pkgSpec = pkgName + "/" + oldPkgDependents[pkgName]
         if verbose:
-            print("OLD: %s" % pkgSpec)
+            print(("OLD: %s" % pkgSpec))
         oldMacroVersions.update( pkgSpecToMacroVersions( pkgSpec ) )
     if len(oldMacroVersions) == 0:
-        print("update_pkg_dependency error: No pkgSpecs found under topDir:\n%s" % topDir)
+        print(("update_pkg_dependency error: No pkgSpecs found under topDir:\n%s" % topDir))
         return 0
 
     # Convert the list of pkgSpecs into a list of macroVersions
@@ -264,7 +264,7 @@ def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
     newMacroVersions = {}
     for pkgSpec in pkgSpecs:
         if verbose:
-            print("NEW: %s" % pkgSpec)
+            print(("NEW: %s" % pkgSpec))
         newMacroVersions.update( pkgSpecToMacroVersions( pkgSpec ) )
     if len(newMacroVersions) == 0:
         print("update_pkg_dependency error: No valid converions for pkgSpecs:")
@@ -274,7 +274,7 @@ def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
     # Remove macros from newMacroVersions if they're already in oldMacroVersions
     # This helps avoid trying to fix commented out macros in configure/RELEASE
     # when they've already been defined in RELEASE.local.
-    for macroName in oldMacroVersions.keys():
+    for macroName in list(oldMacroVersions.keys()):
         if macroName not in newMacroVersions:
             continue
         if oldMacroVersions[macroName] == newMacroVersions[macroName]:
@@ -297,12 +297,12 @@ def update_pkg_dependency( topDir, pkgSpecs, debug=False, verbose=False ):
 def update_stable( topDir='.', debug=False ):
     curDep = getEpicsPkgDependents( topDir, debug=debug )
     if 'base' not in curDep:
-        print "Error: unable to determine base version"
+        print("Error: unable to determine base version")
         return 0
     epicsSiteTop = determine_epics_site_top()
     modulesStableVersionPath = os.path.join( epicsSiteTop, curDep['base'], 'modules', 'MODULES_STABLE_VERSION' )
     if not os.path.isfile( modulesStableVersionPath ):
-        print "Error: unable to find %s" % modulesStableVersionPath 
+        print("Error: unable to find %s" % modulesStableVersionPath) 
         return 0
 
     macroDict = {}
@@ -364,7 +364,7 @@ def main(argv=None):
     if (options.input_file_path):
         try:
             in_file = open(options.input_file_path, 'r')
-        except IOError, e:
+        except IOError as e:
             sys.stderr.write('Could not open "%s": %s\n' % (options.input_file_path, e.strerror))
             return None
 
@@ -379,7 +379,7 @@ def main(argv=None):
             if module and release:
                 options.packages += [ modulePath ]
                 if options.verbose:
-                    print 'Adding: %s' % modulePath
+                    print('Adding: %s' % modulePath)
 
             # repeat above for all lines in file
 
@@ -390,7 +390,7 @@ def main(argv=None):
         curDir = os.getcwd()
         os.chdir( options.top )
         if options.verbose:
-            print "Updating %s/RELEASE_SITE ..." % options.top
+            print("Updating %s/RELEASE_SITE ..." % options.top)
         inputs = assemble_release_site_inputs( batch=True )
         export_release_site_file( inputs, debug=options.verbose )
         os.chdir( curDir )
@@ -402,7 +402,7 @@ def main(argv=None):
     if len( options.packages ) > 0:
         count += update_pkg_dependency( options.top, options.packages, verbose=options.verbose )
 
-    print "Done: Updated %d RELEASE file%s." % ( count, "" if count == 1 else "s" )
+    print("Done: Updated %d RELEASE file%s." % ( count, "" if count == 1 else "s" ))
     return 0
 
 if __name__ == '__main__':

--- a/epics-update.py
+++ b/epics-update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Name: epics-update.py
 #  Abs:  A tool to update EPICS packages
 #

--- a/epics-versions.py
+++ b/epics-versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/epics-versions.py
+++ b/epics-versions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 import re
 import sys
 import optparse

--- a/gitRecommitBranch.py
+++ b/gitRecommitBranch.py
@@ -25,9 +25,9 @@ def importBranchTo( repo, parentBranch, srcBranch, srcBranchEnd=None, mergePoint
 
     if dstBranch is None:
         dstBranch = 'new-branch'
-    print "Importing branch %s w merge points on %s to branch %s" % ( srcBranch, parentBranch, dstBranch )
+    print("Importing branch %s w merge points on %s to branch %s" % ( srcBranch, parentBranch, dstBranch ))
 
-    if mergePoints is None or len(mergePoints.keys()) == 0:
+    if mergePoints is None or len(list(mergePoints.keys())) == 0:
         raise Exception( 'Must provide at least one merge point!' )
  
     srcCommits	= list( repo.iter_commits(srcBranch) )
@@ -37,7 +37,7 @@ def importBranchTo( repo, parentBranch, srcBranch, srcBranchEnd=None, mergePoint
     else:
         initial = srcCommits[-1].hexsha
         if not initial in mergePoints:
-            print "Warning: The first commit on branch %s, %.7s, does not have a merge point!\n" % ( srcBranch, initial )
+            print("Warning: The first commit on branch %s, %.7s, does not have a merge point!\n" % ( srcBranch, initial ))
 
     # Grab the tags so we can remap them as well
     tags = gitRepo.tags
@@ -59,17 +59,17 @@ def importBranchTo( repo, parentBranch, srcBranch, srcBranchEnd=None, mergePoint
             parents = tuple( [ newCommit ] + list(parents)[1:] )
         if lastCommit is not None and commit == lastCommit:
             if verbose:
-                print "Ending  branch at: %.7s" % commit.hexsha
+                print("Ending  branch at: %.7s" % commit.hexsha)
             lastCommit	= None
             parents		= []
         if mergePoint is not None:
             parents	= tuple( list(parents) + [ mergePoint ] )
             if verbose:
-                print "Found merge point: %.7s" % commit.hexsha
-                print "Parents are : (",
+                print("Found merge point: %.7s" % commit.hexsha)
+                print("Parents are : (", end=' ')
                 for p in parents:
-                    print " %.7s" % p.hexsha,
-                print ")"
+                    print(" %.7s" % p.hexsha, end=' ')
+                print(")")
 
         if commit.author_tz_offset < 0:
             author_date	= "%d -%04d" % ( commit.authored_date,  -commit.author_tz_offset/3600	  )
@@ -84,7 +84,7 @@ def importBranchTo( repo, parentBranch, srcBranch, srcBranchEnd=None, mergePoint
                         author=commit.author,		author_date=author_date,
                         committer=commit.committer,	commit_date=commit_date )
         if verbose or mergePoint is not None:
-            print "Created new commit: %.7s from %.7s" % ( newCommit.hexsha, commit.hexsha )
+            print("Created new commit: %.7s from %.7s" % ( newCommit.hexsha, commit.hexsha ))
 
         # Remap any tags from the old commit to the new one
         for tagRef in tags:
@@ -109,12 +109,12 @@ def importBranchTo( repo, parentBranch, srcBranch, srcBranchEnd=None, mergePoint
             else:
                 TagReference.create( gitRepo, tagRef.name, ref=newCommit, force=True )
             if verbose:
-                print "Remapped tag %s to %.7s from %.7s" % ( tagRef.name, newCommit.hexsha, commit.hexsha )
+                print("Remapped tag %s to %.7s from %.7s" % ( tagRef.name, newCommit.hexsha, commit.hexsha ))
 
     new_branch = repo.create_head( dstBranch )
     new_branch.set_commit( newCommit.hexsha )
     if verbose:
-        print "Done importing branch %s.\n" % ( srcBranch )
+        print("Done importing branch %s.\n" % ( srcBranch ))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser( description='''This script recreates the git commit history for a branch w/
@@ -140,16 +140,16 @@ if __name__ == '__main__':
     try:
         branchCommit = gitRepo.commit( args.srcBranch )
     except BadName:
-        print "srcBranch %s is not a valid commit" % args.srcBranch
+        print("srcBranch %s is not a valid commit" % args.srcBranch)
         sys.exit(1)
     try:
         branchCommit = gitRepo.commit( args.parentBranch )
     except BadName:
-        print "parentBranch %s is not a valid commit" % args.parentBranch
+        print("parentBranch %s is not a valid commit" % args.parentBranch)
         sys.exit(1)
     try:
         branchCommit = gitRepo.commit( args.dstBranch )
-        print "dstBranch %s already exists!" % args.dstBranch
+        print("dstBranch %s already exists!" % args.dstBranch)
         sys.exit(1)
     except BadName:
         pass
@@ -158,34 +158,34 @@ if __name__ == '__main__':
     for m in args.mergePoint:
         mergePoint = m.split(':')
         if len(mergePoint) != 2:
-            print "Invalid mergePoint: %s\nShould be 2 colon separated commit identifiers." % m
+            print("Invalid mergePoint: %s\nShould be 2 colon separated commit identifiers." % m)
             sys.exit(1)
 
         # Validate the merge commit
         try:
             mergeCommit	= gitRepo.commit( mergePoint[0] )
         except BadName:
-            print "MergePoint %s is not a valid commit" % mergePoint[0]
+            print("MergePoint %s is not a valid commit" % mergePoint[0])
             sys.exit(1)
         if not gitRepo.is_ancestor( mergeCommit.hexsha, args.srcBranch ):
-            print 'Merge point %.7s is not on branch %s!' % ( mergeCommit.hexsha, args.srcBranch )
+            print('Merge point %.7s is not on branch %s!' % ( mergeCommit.hexsha, args.srcBranch ))
             sys.exit(1)
 
         # Validate the merge parent
         try:
             mergeParent	= gitRepo.commit( mergePoint[1] )
         except BadName:
-            print "MergePoint parent %s is not a valid commit" % mergePoint[1]
+            print("MergePoint parent %s is not a valid commit" % mergePoint[1])
             sys.exit(1)
         if not gitRepo.is_ancestor( mergeParent.hexsha, args.parentBranch ):
             if mergeParent.type == 'tag':
                 if not gitRepo.is_ancestor( mergeParent.object.hexsha, args.parentBranch ):
-                    print 'Warning, parent tag %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch )
+                    print('Warning, parent tag %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch ))
             elif mergeParent.type == 'commit' and mergeParent.parents is not None:
                 if not gitRepo.is_ancestor( mergeParent.parents[0].hexsha, args.parentBranch ):
-                    print 'Warning, parent commit %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch )
+                    print('Warning, parent commit %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch ))
             else:
-                print 'Warning, commit %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch )
+                print('Warning, commit %.7s is not on parent branch %s!' % ( mergeParent.hexsha, args.parentBranch ))
 
         # Register the mergePoint
         mergePoints[ mergeCommit.hexsha ] = mergeParent
@@ -193,5 +193,5 @@ if __name__ == '__main__':
     # Import the branch
     importBranchTo( gitRepo, args.parentBranch, args.srcBranch, args.srcBranchEnd, dstBranch=args.dstBranch, mergePoints=mergePoints, verbose=args.verbose )
 
-    print "Done."
+    print("Done.")
 

--- a/gitRecommitBranch.py
+++ b/gitRecommitBranch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script imports a git repository branch from a git branch w/ a different origin.
 Typically this will happen when combining version histories of the same
 package from different version control systems and/or repositories.

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -36,9 +36,9 @@ class gitRepo( Repo.Repo ):
 
     def CheckoutRelease( self, buildDir, verbose=True, quiet=False, dryRun=False, depth=None ):
         if verbose:
-            print "Checking out: %s\nto build dir: %s ..." % ( self._url, buildDir )
+            print("Checking out: %s\nto build dir: %s ..." % ( self._url, buildDir ))
         if dryRun:
-            print "CheckoutRelease: --dryRun--"
+            print("CheckoutRelease: --dryRun--")
             return
 
         outputPipe = None
@@ -69,12 +69,12 @@ class gitRepo( Repo.Repo ):
                     os.chdir( curDir )
                     return
 
-            except RuntimeError, e:
-                print e
+            except RuntimeError as e:
+                print(e)
                 pass
 
-            except subprocess.CalledProcessError, e:
-                print e
+            except subprocess.CalledProcessError as e:
+                print(e)
                 pass
 
         if not os.path.isdir( os.path.join( buildDir, '.git' ) ):
@@ -88,14 +88,14 @@ class gitRepo( Repo.Repo ):
                 # Clone the repo
                 cloneUpstreamRepo( self._url, buildDir, '', branch=self._tag, depth=depth )
                 os.chdir( buildDir )
-            except RuntimeError, e:
-                print e
+            except RuntimeError as e:
+                print(e)
                 os.chdir(curDir)
-                raise gitError, "CheckoutRelease RuntimeError: Failed to clone %s to %s" % ( self._url, buildDir )
-            except subprocess.CalledProcessError, e:
-                print e
+                raise gitError("CheckoutRelease RuntimeError: Failed to clone %s to %s" % ( self._url, buildDir ))
+            except subprocess.CalledProcessError as e:
+                print(e)
                 os.chdir(curDir)
-                raise gitError, "CheckoutRelease CalledProcessError: Failed to clone %s in %s" % ( self._url, buildDir )
+                raise gitError("CheckoutRelease CalledProcessError: Failed to clone %s in %s" % ( self._url, buildDir ))
 
         # See if we've already created a branch for this tag
         branchSha = None
@@ -104,14 +104,14 @@ class gitRepo( Repo.Repo ):
             gitOutput = subprocess.check_output( cmdList ).splitlines()
             if len(gitOutput) == 1:
                 branchSha = gitOutput[0]
-        except subprocess.CalledProcessError, e:
+        except subprocess.CalledProcessError as e:
             pass
 
         try:
             # Refresh the tags
             # TODO: May fail if git repo is read-only
             if verbose:
-                print "CheckoutRelease running: git fetch origin refs/tags/%s" % self._tag
+                print("CheckoutRelease running: git fetch origin refs/tags/%s" % self._tag)
             cmdList = [ "git", "fetch", "origin", "refs/tags/" + self._tag ]
             subprocess.check_call( cmdList, stdout=outputPipe, stderr=outputPipe )
 
@@ -148,14 +148,14 @@ class gitRepo( Repo.Repo ):
                     inputs = assemble_release_site_inputs( batch=True )
                     export_release_site_file( inputs )
 
-        except RuntimeError, e:
-            print e
+        except RuntimeError as e:
+            print(e)
             os.chdir(curDir)
-            raise gitError, "CheckoutRelease RuntimeError: Failed to checkout %s in %s" % ( self._tag, buildDir )
-        except subprocess.CalledProcessError, e:
-            print e
+            raise gitError("CheckoutRelease RuntimeError: Failed to checkout %s in %s" % ( self._tag, buildDir ))
+        except subprocess.CalledProcessError as e:
+            print(e)
             os.chdir(curDir)
-            raise gitError, "CheckoutRelease CalledProcessError: Failed to checkout %s in %s" % ( self._tag, buildDir )
+            raise gitError("CheckoutRelease CalledProcessError: Failed to checkout %s in %s" % ( self._tag, buildDir ))
         os.chdir(curDir)
 
     def RemoveTag( self, package=None, tag=None, verbose=True, dryRun=False ):
@@ -163,44 +163,44 @@ class gitRepo( Repo.Repo ):
             package = self._package
             tag = self._tag
         if verbose:
-            print "\nRemoving %s release tag %s ..." % ( package, tag )
+            print("\nRemoving %s release tag %s ..." % ( package, tag ))
         subprocess.check_call( [ "git", "tag", "-d", tag ] )
         subprocess.check_call( [ 'git', 'push', '--delete', 'origin', tag ] )
-        print "Successfully removed %s release tag %s." % ( package, tag )
+        print("Successfully removed %s release tag %s." % ( package, tag ))
 
     def PushBranch( self, branchName=None, verbose=True, dryRun=False ):
         if branchName is None:
             branchName = self._branch
         if branchName is None:
             if verbose or dryRun:
-                print "No branch to push"
+                print("No branch to push")
             return
 
         if dryRun:
-            print "--dryRun-- Push Branch %s" % ( branchName )
+            print("--dryRun-- Push Branch %s" % ( branchName ))
             return
         if verbose:
-            print "Pushing branch %s ..." % ( branchName )
+            print("Pushing branch %s ..." % ( branchName ))
         subprocess.check_call( [ 'git', 'push', 'origin', branchName ] )
 
     def PushTag( self, release, verbose=True, dryRun=False ):
         if dryRun:
-            print "--dryRun-- Push tag %s" % ( release )
+            print("--dryRun-- Push tag %s" % ( release ))
             return
 
         if verbose:
-            print "Pushing tag %s ..." % ( release )
+            print("Pushing tag %s ..." % ( release ))
         subprocess.check_call( [ 'git', 'push', 'origin', release ] )
 
     def TagRelease( self, packagePath=None, release=None, branch=None, message="", verbose=True, dryRun=False ):
         if release is None:
             release = self._tag
         if dryRun:
-            print "--dryRun-- Tag %s release %s" % ( packagePath, release )
+            print("--dryRun-- Tag %s release %s" % ( packagePath, release ))
             return
 
         if verbose:
-            print "Tagging %s release %s ..." % ( packagePath, release )
+            print("Tagging %s release %s ..." % ( packagePath, release ))
         comment = "Release %s/%s: %s" % ( packagePath, release, message )
         cmdList = [ "git", "tag", release, 'HEAD', "-m", comment ]
         subprocess.check_call( cmdList )

--- a/git_utils.py
+++ b/git_utils.py
@@ -165,11 +165,11 @@ def gitGetRemoteTags( url, debug = False, verbose = False ):
     try:
         if verbose:
             print("gitGetRemoteTags running: git ls-remote %s" % url)
-        statusInfo = subprocess.check_output( [ 'git', 'ls-remote', url ], stderr=subprocess.STDOUT )
+        statusInfo = subprocess.check_output( [ 'git', 'ls-remote', url ], stderr=subprocess.STDOUT, universal_newlines=True )
         for line in statusInfo.splitlines():
             if line is None:
                 break
-            tagSpecMatch = tagSpecRegExp.search( line.decode('utf-8') )
+            tagSpecMatch = tagSpecRegExp.search( line )
             if not tagSpecMatch:
                 continue
             tags[ tagSpecMatch.group(2) ] = tagSpecMatch.group(1)

--- a/git_utils.py
+++ b/git_utils.py
@@ -169,7 +169,7 @@ def gitGetRemoteTags( url, debug = False, verbose = False ):
         for line in statusInfo.splitlines():
             if line is None:
                 break
-            tagSpecMatch = tagSpecRegExp.search( line )
+            tagSpecMatch = tagSpecRegExp.search( line.decode('utf-8') )
             if not tagSpecMatch:
                 continue
             tags[ tagSpecMatch.group(2) ] = tagSpecMatch.group(1)

--- a/git_utils.py
+++ b/git_utils.py
@@ -40,7 +40,7 @@ def parseGitModulesTxt():
             continue
         parts = line.split()
         if(len(parts) < 2):
-            print "Error parsing ", gitModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs"
+            print("Error parsing ", gitModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs")
             continue
         packageName = parts[0]
         packageLocation = expandMacros( parts[1], os.environ )
@@ -78,10 +78,10 @@ def git_call( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
     if gitDir is not None:
         cmdList.insert( 1, [ '--git-dir', gitDir ] )
     if debug:
-        print "git_call running: %s" % ' '.join( cmdList )
+        print("git_call running: %s" % ' '.join( cmdList ))
     callStatus = subprocess.call( cmdList, *args, **kwargs )
     if debug:
-        print "git_call  status:", callStatus
+        print("git_call  status:", callStatus)
     return callStatus
 
 def git_check_call( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
@@ -93,7 +93,7 @@ def git_check_call( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
     May throw RuntimeError or subprocess.CalledProcessError exceptions
     '''
     cmdList = []
-    if isinstance( gitCommand, basestring ):
+    if isinstance( gitCommand, str ):
         if not gitCommand.startswith( 'git ' ):
             cmdList = [ 'git' ]
         cmdList += gitCommand.split()
@@ -104,10 +104,10 @@ def git_check_call( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
     if gitDir is not None:
         cmdList.insert( 1, [ '--git-dir', gitDir ] )
     if debug:
-        print "git_check_call running: %s" % ' '.join( cmdList )
+        print("git_check_call running: %s" % ' '.join( cmdList ))
     callStatus = subprocess.check_call( cmdList, *args, **kwargs )
     if debug:
-        print "git_check_call  status:", callStatus
+        print("git_check_call  status:", callStatus)
     return callStatus
 
 def git_check_output( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
@@ -132,12 +132,12 @@ def git_check_output( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
         cmdList.insert( 1, [ '--git-dir', gitDir ] )
 
     if debug:
-        print "git_check_output running: %s" % ' '.join( cmdList )
+        print("git_check_output running: %s" % ' '.join( cmdList ))
 
     git_output = subprocess.check_output( cmdList, *args, **kwargs )
 
     if debug:
-        print git_output
+        print(git_output)
     return git_output
 
 def gitGetRemoteFile( url, refName, filePath, debug = False ):
@@ -147,13 +147,13 @@ def gitGetRemoteFile( url, refName, filePath, debug = False ):
     try:
         commitSpec = refName + ':' + filePath
         fileContents = subprocess.check_output( [ 'git', '--git-dir=%s' % url, 'show', commitSpec ], stderr=subprocess.STDOUT )
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     return fileContents
 
@@ -164,7 +164,7 @@ def gitGetRemoteTags( url, debug = False, verbose = False ):
     tags = {}
     try:
         if verbose:
-            print "gitGetRemoteTags running: git ls-remote %s" % url
+            print("gitGetRemoteTags running: git ls-remote %s" % url)
         statusInfo = subprocess.check_output( [ 'git', 'ls-remote', url ], stderr=subprocess.STDOUT )
         for line in statusInfo.splitlines():
             if line is None:
@@ -174,16 +174,16 @@ def gitGetRemoteTags( url, debug = False, verbose = False ):
                 continue
             tags[ tagSpecMatch.group(2) ] = tagSpecMatch.group(1)
 
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     if verbose:
-        print "gitGetRemoteTags: Found %d tags in %s" % ( len(tags), url )
+        print("gitGetRemoteTags: Found %d tags in %s" % ( len(tags), url ))
     return tags
 
 def gitGetRemoteTag( url, tag, debug = False, verbose = False ):
@@ -206,21 +206,21 @@ def gitGetRemoteTag( url, tag, debug = False, verbose = False ):
             git_tag = tag
             tag_sha = tags[tag]
 
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     if verbose:
         if git_url:
-            print "gitGetRemoteTag: Found git_tag %s %7.7s in git_url %s" % ( git_tag, tag_sha, git_url )
+            print("gitGetRemoteTag: Found git_tag %s %7.7s in git_url %s" % ( git_tag, tag_sha, git_url ))
         elif url_valid:
-            print "gitGetRemoteTag: Unable to find tag %s in git url %s" % ( tag, url )
+            print("gitGetRemoteTag: Unable to find tag %s in git url %s" % ( tag, url ))
         else:
-            print "gitGetRemoteTag: Invalid git url %s" % ( url )
+            print("gitGetRemoteTag: Invalid git url %s" % ( url ))
     return ( tag_sha, git_tag )
 
 def gitGetTagSha( tag ):
@@ -244,10 +244,10 @@ def initBareRepo( gitRepoPath, verbose=False ):
     # Make sure parent folder exists
     ( parentFolder, module )  = os.path.split( gitRepoPath )
     if not os.path.isdir( parentFolder ):
-        if verbose: print "Pre-creating parent folder for " + gitRepoPath
-        os.makedirs( parentFolder, 0775 )
+        if verbose: print("Pre-creating parent folder for " + gitRepoPath)
+        os.makedirs( parentFolder, 0o775 )
 
-    if verbose: print "Creating a new bare repo in " + gitRepoPath
+    if verbose: print("Creating a new bare repo in " + gitRepoPath)
     subprocess.check_call(["git", "init", "--bare", "--template=%s/templates" % DEF_GIT_MODULES_PATH, gitRepoPath])
     if not os.path.exists(gitRepoPath):
         raise Exception( "Failed to create git repo at:\n" + gitRepoPath )
@@ -269,7 +269,7 @@ def cloneUpstreamRepo( gitUpstreamRepo, tpath, packageName, branch=None, depth=N
     if depth:
         gitCommand += " --no-local --depth %d" % depth
     #May throw RuntimeError or subprocess.CalledProcessError exceptions
-    print prompt
+    print(prompt)
     #print "%s" % prompt
     git_check_call( gitCommand, debug=verbose )
     return clonedFolder
@@ -306,10 +306,10 @@ def gitCommitAndPush( message ):
 def addPackageToEcoModuleList(packageName, gitUpstreamRepo):
     '''Add the package with the given upstream repo to eco's modulelist'''
     curDir = os.getcwd()
-    print "Adding package", packageName, "to eco_modulelist"
+    print("Adding package", packageName, "to eco_modulelist")
     tools_dir = os.environ['TOOLS']
     if not tools_dir:
-        print 'addPackageToEcoModuleList Error: TOOLS env not defined.'
+        print('addPackageToEcoModuleList Error: TOOLS env not defined.')
         return
     gitModulesTxtFolder = os.path.join(os.environ['TOOLS'], 'eco_modulelist')
     os.chdir(gitModulesTxtFolder)
@@ -381,13 +381,13 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
             # Just grab the first tag that matches
             repo_tag = statusLines[0].split('^')[0]
 
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     return ( repo_url, repo_branch, repo_tag )
 
@@ -440,7 +440,7 @@ def determinePathToGitRepo( packagePath, verbose = False ):
 def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
     (repo_url, repo_tag) = (None, None)
     if verbose:
-        print "gitFindPackageRelease( packageSpec=%s, tag=%s )" % ( packageSpec, tag )
+        print("gitFindPackageRelease( packageSpec=%s, tag=%s )" % ( packageSpec, tag ))
     if tag:
         packagePath = packageSpec
     else:
@@ -450,7 +450,7 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
     else:
         packageName = packagePath
     if verbose:
-        print "gitFindPackageRelease: packageName=%s, packagePath=%s" % ( packageName, packagePath )
+        print("gitFindPackageRelease: packageName=%s, packagePath=%s" % ( packageName, packagePath ))
 
     # See if the package was listed in $TOOLS/eco_modulelist/modulelist.txt
     if packageName in git_package2Location:
@@ -473,9 +473,9 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
 
     if verbose:
         if repo_url:
-            print "gitFindPackageRelease found %s/%s: url=%s, tag=%s" % ( packagePath, tag, repo_url, repo_tag )
+            print("gitFindPackageRelease found %s/%s: url=%s, tag=%s" % ( packagePath, tag, repo_url, repo_tag ))
         else:
-            print "gitFindPackageRelease Error: Cannot find %s/%s" % (packagePath, tag)
+            print("gitFindPackageRelease Error: Cannot find %s/%s" % (packagePath, tag))
     return (repo_url, repo_tag)
 
 def git_get_versionFileName():

--- a/git_utils2.py
+++ b/git_utils2.py
@@ -14,7 +14,7 @@ def parseGitModulesTxt():
             continue
         parts = line.split()
         if(len(parts) < 2):
-            print "Error parsing ", gitModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs"
+            print("Error parsing ", gitModulesTxtFile, "Cannot break", line, "into columns with enough fields using spaces/tabs")
             continue
         packageName = parts[0]
         packageLocation = parts[1]

--- a/installLinks.py
+++ b/installLinks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # installLinks.py
 # Must have --buildTop arg as a src
 # Optional: --installTop to specify destination TOP or defaults to current dir

--- a/installLinks.py
+++ b/installLinks.py
@@ -45,10 +45,10 @@ from version_utils import *
 
 def make_links( buildTop, installTop, subdir, arch=None, force=False, is_site_packages = False, is_pyinc = False, python='python2.7', verbose=False ):
     if not os.path.exists(buildTop):
-        print "Error: buildTop %s does not exist!" % buildTop
+        print("Error: buildTop %s does not exist!" % buildTop)
         return
     if not os.path.exists(installTop):
-        print "Error: installTop %s does not exist!" % installTop
+        print("Error: installTop %s does not exist!" % installTop)
         return
     if is_site_packages:
         subdir = 'lib/%s/site-packages' % python
@@ -56,7 +56,7 @@ def make_links( buildTop, installTop, subdir, arch=None, force=False, is_site_pa
         subdir = 'include/%s' % python
     for target in glob.glob('%s/%s/*' % ( buildTop, subdir ) ):
         if not os.path.exists(target):
-            print '%s does not exist' % target
+            print('%s does not exist' % target)
             continue
         (target_dir, target_base) = os.path.split( target )
         if subdir == 'lib' and target_base == python:
@@ -66,7 +66,7 @@ def make_links( buildTop, installTop, subdir, arch=None, force=False, is_site_pa
 
         # Make sure the sub-directory path exists
         if not os.path.isdir( os.path.join( installTop, subdir ) ):
-            os.makedirs( os.path.join( installTop, subdir ), 0775 )
+            os.makedirs( os.path.join( installTop, subdir ), 0o775 )
 
         # Create symlink filename
         if ( subdir == 'bin' or subdir == 'lib' ) and arch is not None:
@@ -77,8 +77,8 @@ def make_links( buildTop, installTop, subdir, arch=None, force=False, is_site_pa
         # See if the target is a directory and if so, recurse
         if os.path.isdir( target ):
             if not os.path.isdir( symlink ):
-                print "mkdir %s ..." % symlink
-                os.makedirs( symlink, 0775 )
+                print("mkdir %s ..." % symlink)
+                os.makedirs( symlink, 0o775 )
             [ symlink_path, symlink_subdir ] = os.path.split( symlink )
             [ target_path, target_subdir ] = os.path.split( target )
             make_links( target_path, symlink_path, symlink_subdir, arch=arch, force=force, is_site_packages=is_site_packages, is_pyinc=is_pyinc, python=python, verbose=verbose )
@@ -104,25 +104,25 @@ def make_links( buildTop, installTop, subdir, arch=None, force=False, is_site_pa
             msg += "    %s\n" % existing_target
             msg += "    %s" % target
             if verbose:
-                print msg
+                print(msg)
 
             if force:
                 # Remove the prior value
-                print "Removing prior link %s ..." % symlink
+                print("Removing prior link %s ..." % symlink)
                 os.remove( symlink )
             else:
-                print "Skipping link %s ..." % symlink
+                print("Skipping link %s ..." % symlink)
                 continue
 
         if not force and not os.path.islink(symlink) and os.path.exists(symlink):
-            print "Skipping pre-existing %s ..." % symlink
+            print("Skipping pre-existing %s ..." % symlink)
             continue
 
         # Remove pre-existing link or file
         if os.path.lexists(symlink):
             os.remove( symlink )
 
-        print "Creating link %s ..." % symlink
+        print("Creating link %s ..." % symlink)
         #print "%s -> %s" % ( symlink, target )
         os.symlink( target, symlink )
     return
@@ -136,7 +136,7 @@ def installLinksFromFile( releaseFile, installTop, debug=False, force=False, ver
     macroDict['TOP'] = installTop
     # Get the base and dependent modules from RELEASE files
     if not os.path.isfile( releaseFile ):
-        print "installLinksFromFile Error - Unable to open releaseFile: %s" % releaseFile
+        print("installLinksFromFile Error - Unable to open releaseFile: %s" % releaseFile)
         return
 
     macroDict = getMacrosFromFile( releaseFile, macroDict, debug=debug )
@@ -146,7 +146,7 @@ def installLinksFromFile( releaseFile, installTop, debug=False, force=False, ver
         if not pkgName:
             continue
         if not isReleaseCandidate(buildTop):
-            print "installLinksFromFile Error - Not an EPICS release: %s" % buildTop
+            print("installLinksFromFile Error - Not an EPICS release: %s" % buildTop)
         else:
             make_release_links( buildTop, installTop, force=False )
 
@@ -203,7 +203,7 @@ $EXTENSION_TOP/bin/linux-x86_64/file2 -> $GATEWAY_TOP/bin/linux-x86_64/file2
     elif options.buildTop:
         make_release_links( options.buildTop, options.installTop, arch=options.arch, force=options.force, verbose=options.verbose )
     else:
-        print "No release builds specified.  Try using -f or -b options."
+        print("No release builds specified.  Try using -f or -b options.")
         parser.print_usage()
 
 if __name__ == '__main__':

--- a/latest_versions.py
+++ b/latest_versions.py
@@ -9,7 +9,7 @@ from version_utils import *
 def update_latest( top='.' ):
     pkgDep = getEpicsPkgDependents( top )
     if 'base' not in pkgDep:
-        print "Error: unable to determine base version"
+        print("Error: unable to determine base version")
         return -1
     epicsSiteTop = determine_epics_site_top()
     epicsModules = os.path.join( epicsSiteTop, pkgDep['base'], 'modules' )
@@ -20,11 +20,11 @@ def update_latest( top='.' ):
         l1 = getPkgReleaseList( epicsModules, pkg )
         l2 = ExpandPackagePath( epicsModules, pkg )
         if len(l1) != len(l2):
-            print "getPkgReleaseList: %s %d releases: " % ( pkg, len(l1) )
-            print "ExpandPackageList: %s %d releases: " % ( pkg, len(l2) )
+            print("getPkgReleaseList: %s %d releases: " % ( pkg, len(l1) ))
+            print("ExpandPackageList: %s %d releases: " % ( pkg, len(l2) ))
         elif l1 != l2:
-            print "getPkgReleaseList: %s releases: %s" % ( pkg, l1 )
-            print "ExpandPackageList: %s releases: %s" % ( pkg, l2 )
+            print("getPkgReleaseList: %s releases: %s" % ( pkg, l1 ))
+            print("ExpandPackageList: %s releases: %s" % ( pkg, l2 ))
         pkgReleases[pkg] = l1
         #print "%s %d releases: " % ( pkg, len(pkgReleases) )
     pprint( pkgReleases )
@@ -37,7 +37,7 @@ def update_latest( top='.' ):
         #if dep in stableVersions:
         #	updateVersions[dep] = stableVersions[dep]
     for dep in updateVersions:
-        print "Need to update %s to %s\n" % ( dep, updateVersions[dep] )
+        print("Need to update %s to %s\n" % ( dep, updateVersions[dep] ))
 
 def main(argv=None):
     parser = argparse.ArgumentParser()

--- a/latest_versions.py
+++ b/latest_versions.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 import argparse
 from pprint import *
 from repo_defaults import *

--- a/makeModules.py
+++ b/makeModules.py
@@ -48,7 +48,7 @@ for path, dirnames, filenames in os.walk('.'):
 #    print 'ls %r' % path
 # We look for folders named configure that have a file named RELEASE
     if ('configure' in dirnames and 'RELEASE' in os.listdir(os.path.join(path, 'configure'))):
-        print 'Module: ' + repr(moduleName(path)) + ' Version: ' + repr(versionName(path))
+        print('Module: ' + repr(moduleName(path)) + ' Version: ' + repr(versionName(path)))
         thismoduleversion = moduleName(path) + '/' + versionName(path)
         paths.add(thismoduleversion)
         dependencies[thismoduleversion] = set([])
@@ -82,12 +82,12 @@ for path, dirnames, filenames in os.walk('.'):
                     if(moduleversionvar not in versionpathswithinmodule):
                         raise Exception('Cannot determine value of version variable ' + moduleversionvar + ' when processing RELEASE file for ' + path)
                     moduleversionpath = modulename + '/' + versionpathswithinmodule[moduleversionvar]
-                    print '\t\tDepends on: ' + moduleversionpath
+                    print('\t\tDepends on: ' + moduleversionpath)
                     dependencies[thismoduleversion].add(moduleversionpath)
                 else:
 # Here we had an absolute path like asyn/asyn-R4-17-RC1-lcls1; so no lookup or processing is needed
                     moduleversionpath = modulepartialpath
-                    print '\t\tDepends on: ' + moduleversionpath
+                    print('\t\tDepends on: ' + moduleversionpath)
                     dependencies[thismoduleversion].add(moduleversionpath)
 
 
@@ -134,10 +134,10 @@ for path in paths:
 for path in buildorder:
     cmd = 'make'
     arguments = sys.argv[1:]
-    print
-    print '\033[95mCalling ' + cmd +  ' ' + str(arguments) +' in folder ' + path + '\033[0m'
-    print
+    print()
+    print('\033[95mCalling ' + cmd +  ' ' + str(arguments) +' in folder ' + path + '\033[0m')
+    print()
     args = [cmd] + arguments
-    print args
+    print(args)
     subprocess.check_call(args, shell=False, cwd=path);
 

--- a/makeModules.py
+++ b/makeModules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #==============================================================
 #
 #  makeModules.py:  A tool to automate the builds of modules. 

--- a/pkgNamesToMacroNames.py
+++ b/pkgNamesToMacroNames.py
@@ -61,11 +61,11 @@ def pkgNameAddMacroName( pkgName, macroName ):
     else:
         if _macroNameToPkgName[macroName] != pkgName:
             if _macroNameToPkgName[macroName] is None:
-                print("pkgNameAddMacroName Error: Pkg %s Macro %s is not a valid pkgName" % \
-                        ( pkgName, macroName ))
+                print(("pkgNameAddMacroName Error: Pkg %s Macro %s is not a valid pkgName" % \
+                        ( pkgName, macroName )))
             else:
-                print("pkgNameAddMacroName Error: Pkg %s Macro %s already mapped to %s" % \
-                        ( pkgName, macroName, _macroNameToPkgName[macroName] ))
+                print(("pkgNameAddMacroName Error: Pkg %s Macro %s already mapped to %s" % \
+                        ( pkgName, macroName, _macroNameToPkgName[macroName] )))
 
 # Populate macro names for packages
 # Most of these are all just simple mappings to uppercase

--- a/site_utils.py
+++ b/site_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 from repo_defaults import *

--- a/site_utils.py
+++ b/site_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 import os
 from repo_defaults import *
 from version_utils import *
@@ -177,7 +177,7 @@ def assemble_release_site_inputs( batch=False ):
     input_dict['EPICS_BASE_VER'] = epics_base_ver
     if not batch:
         prompt5 = 'Enter EPICS_BASE_VER or [RETURN] to use "' + epics_base_ver + '">'
-        user_input = raw_input(prompt5).strip()
+        user_input = input(prompt5).strip()
         if user_input:
             input_dict['EPICS_BASE_VER'] = user_input
     print('Using EPICS_BASE_VER: ' + input_dict['EPICS_BASE_VER'])
@@ -191,7 +191,7 @@ def assemble_release_site_inputs( batch=False ):
     input_dict['EPICS_SITE_TOP'] = epics_site_top
     if not batch:
         prompt1 = 'Enter full path for EPICS_SITE_TOP or [RETURN] to use "' + epics_site_top + '">'
-        user_input = raw_input(prompt1).strip()
+        user_input = input(prompt1).strip()
         if user_input:
             input_dict['EPICS_SITE_TOP'] = user_input
     print('Using EPICS_SITE_TOP: ' + input_dict['EPICS_SITE_TOP'])
@@ -213,7 +213,7 @@ def assemble_release_site_inputs( batch=False ):
         input_dict['EPICS_MODULES'] = epics_modules
     if not batch:
         prompt5 = 'Enter full path for EPICS_MODULES or [RETURN] to use "' + input_dict['EPICS_MODULES'] + '">'
-        user_input = raw_input(prompt5).strip()
+        user_input = input(prompt5).strip()
         if user_input:
             input_dict['EPICS_MODULES'] = user_input
     print('Using EPICS_MODULES: ' + input_dict['EPICS_MODULES'])
@@ -235,7 +235,7 @@ def assemble_release_site_inputs( batch=False ):
     input_dict['PACKAGE_SITE_TOP'] = package_site_top
     if not batch:
         prompt6 = 'Enter full path for PACKAGE_SITE_TOP or [RETURN] to use "' + package_site_top + '">'
-        user_input = raw_input(prompt6).strip()
+        user_input = input(prompt6).strip()
         if user_input:
             input_dict['PACKAGE_SITE_TOP'] = user_input
     print('Using PACKAGE_SITE_TOP: ' + input_dict['PACKAGE_SITE_TOP'])
@@ -272,7 +272,7 @@ def assemble_release_site_inputs( batch=False ):
         input_dict['TOOLS_SITE_TOP'] = tools_site_top
         if not batch:
             prompt6 = 'Enter full path for TOOLS_SITE_TOP or [RETURN] to use "' + tools_site_top + '">'
-            user_input = raw_input(prompt6).strip()
+            user_input = input(prompt6).strip()
             if user_input:
                 input_dict['TOOLS_SITE_TOP'] = user_input
         if os.path.isdir( input_dict['TOOLS_SITE_TOP'] ):
@@ -282,7 +282,7 @@ def assemble_release_site_inputs( batch=False ):
             input_dict['ALARM_CONFIGS_TOP'] = alarm_configs_top
             if not batch:
                 prompt6 = 'Enter full path for ALARM_CONFIGS_TOP or [RETURN] to use "' + alarm_configs_top + '">'
-                user_input = raw_input(prompt6).strip()
+                user_input = input(prompt6).strip()
                 if user_input:
                     input_dict['ALARM_CONFIGS_TOP'] = user_input
             if os.path.isdir( input_dict['ALARM_CONFIGS_TOP'] ):

--- a/svnIocToGit.py
+++ b/svnIocToGit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script import a PCDS EPICS IOC from svn to a git repo.'''
 import sys
 import argparse

--- a/svnIocToGit.py
+++ b/svnIocToGit.py
@@ -26,9 +26,9 @@ def importIOC( iocSpec, name=None, trunk=None, branches=[], tags=[], gitUrl=None
         if not svnPathExists( os.path.join(svnRepoRoot, trunk) ):
             trunk = os.path.join( svnRepoTrunkPath, iocSpec )
     if not svnPathExists( os.path.join(svnRepoRoot, trunk) ):
-        print( "Error: trunk path does not exist: %s" % os.path.join(svnRepoRoot, trunk) )
+        print(( "Error: trunk path does not exist: %s" % os.path.join(svnRepoRoot, trunk) ))
         return
-    print "Importing svn IOC %s from %s" % ( iocSpec, trunk )
+    print("Importing svn IOC %s from %s" % ( iocSpec, trunk ))
     svn_tags  = [ os.path.join( svnRepoTagsPath, iocSpec ) ]
     svn_tags += tags
     if name is None:
@@ -44,11 +44,11 @@ def importTrunk( trunk, name, gitUrl, branches=[], tags=[], verbose=False, batch
     tpath = tempfile.mkdtemp()
     tmpGitRepoPath = os.path.join( tpath, name )
     if os.path.isdir( gitUrl ):
-        print "svn import of repo already exists:", gitUrl
+        print("svn import of repo already exists:", gitUrl)
         return
 
     if trunk.startswith( svnRepoRoot ):
-        print "Error: trunk path should not include base svn repo path: %s" % trunk
+        print("Error: trunk path should not include base svn repo path: %s" % trunk)
         return
 
     # Create the git svn clone command
@@ -57,27 +57,27 @@ def importTrunk( trunk, name, gitUrl, branches=[], tags=[], verbose=False, batch
                     "--trunk", trunk ]
     for b in branches:
         if b.startswith( svnRepoRoot ):
-            print "Error: branch path should not include base svn repo path: %s" % b
+            print("Error: branch path should not include base svn repo path: %s" % b)
             return
         git_cmd.extend( [ "--branches", b ] )
 
     for t in tags:
         if t.startswith( svnRepoRoot ):
-            print "Error: tags path should not include base svn repo path: %s" % t
+            print("Error: tags path should not include base svn repo path: %s" % t)
             return
         git_cmd.extend( [ "--tags", t ] )
 
-    print "Import svn trunk %s\n   to %s:" % ( trunk, gitUrl )
+    print("Import svn trunk %s\n   to %s:" % ( trunk, gitUrl ))
     git_cmd.extend( [ svnRepoRoot, tmpGitRepoPath ] )
 
     if verbose:
-        print "git cmd:",
+        print("git cmd:", end=' ')
         for arg in git_cmd:
-            print arg,
-        print
+            print(arg, end=' ')
+        print()
 
     if not batch:
-        confirmResp = raw_input( 'Proceed (Y/n)?' )
+        confirmResp = input( 'Proceed (Y/n)?' )
         if len(confirmResp) != 0 and confirmResp != "Y" and confirmResp != "y":
             return
 
@@ -122,7 +122,7 @@ Additional paths for both branches and tags may be added if desired either way.
     args = parser.parse_args( )
 
     if args.iocSpec and args.trunk:
-        print 'Please specify either a IOC specification or a trunk path, not both.'    
+        print('Please specify either a IOC specification or a trunk path, not both.')    
         sys.exit()
 
     if args.filename:
@@ -139,25 +139,25 @@ Additional paths for both branches and tags may be added if desired either way.
                     continue
                 gitUrl = os.path.join( gitEpicsRoot, iocSpec + '.git' )
                 if os.path.isdir( gitUrl ):
-                    print( "%s: Already imported" % iocSpec )
+                    print(( "%s: Already imported" % iocSpec ))
                     continue
                 importIOC( iocSpec, verbose=args.verbose, batch=True )
         except Exception as e:
-            print( "Error opening %s: %s" % ( args.filename, e ) )
+            print(( "Error opening %s: %s" % ( args.filename, e ) ))
     elif args.iocSpec:
         importIOC( args.iocSpec, name=args.name, trunk=args.trunk, branches=args.branches,
                       tags=args.tags, gitUrl=args.URL, verbose=args.verbose )
     elif args.trunk is not None or len(args.branches) > 0:
         if not args.name:
-            print 'Please provide a name for git repo'
+            print('Please provide a name for git repo')
             sys.exit()
         if  args.trunk is None:
             args.trunk = args.branches[0]
         importTrunk( args.trunk, args.name, args.URL, args.branches[1:], args.tags, args.verbose )
     else:
         parser.print_help()
-        print 'Please provide a iocSpec name, or one or more branches to import'
+        print('Please provide a iocSpec name, or one or more branches to import')
         sys.exit() 
 
-    print "Done."
+    print("Done.")
 

--- a/svnModuleToGit.py
+++ b/svnModuleToGit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''This script import a PCDS EPICS module from svn to a git repo.'''
 import sys
 import argparse

--- a/svnModuleToGit.py
+++ b/svnModuleToGit.py
@@ -23,7 +23,7 @@ if svnRepoEnvVar in os.environ:
 def importModule( module, name=None, trunk=None, branches=[], tags=[], verbose=False ):
     if  trunk is None: 
         trunk = os.path.join( svnRepoTrunkPath, module, "current" )
-    print "Importing svn module %s from %s" % ( module, trunk )
+    print("Importing svn module %s from %s" % ( module, trunk ))
     svn_tags  = [ os.path.join( svnRepoTagsPath, module ) ]
     svn_tags += tags
     if name is None:
@@ -37,11 +37,11 @@ def importTrunk( trunk, name, gitRoot, branches=[], tags=[], verbose=False ):
     tmpGitRepoPath = os.path.join( tpath, name )
     svnGitRepoPath = os.path.join( gitRoot, name + '.git' )
     if os.path.isdir( svnGitRepoPath ):
-        print "svn import of repo already exists:", svnGitRepoPath
+        print("svn import of repo already exists:", svnGitRepoPath)
         return
 
     if trunk.startswith( svnRepoRoot ):
-        print "Error: trunk path should not include base svn repo path: %s" % trunk
+        print("Error: trunk path should not include base svn repo path: %s" % trunk)
         return
 
     # Create the git svn clone command
@@ -50,26 +50,26 @@ def importTrunk( trunk, name, gitRoot, branches=[], tags=[], verbose=False ):
                     "--trunk", trunk ]
     for b in branches:
         if b.startswith( svnRepoRoot ):
-            print "Error: branch path should not include base svn repo path: %s" % b
+            print("Error: branch path should not include base svn repo path: %s" % b)
             return
         git_cmd.extend( [ "--branches", b ] )
 
     for t in tags:
         if t.startswith( svnRepoRoot ):
-            print "Error: tags path should not include base svn repo path: %s" % t
+            print("Error: tags path should not include base svn repo path: %s" % t)
             return
         git_cmd.extend( [ "--tags", t ] )
 
-    print "Import svn trunk %s\n   to %s:" % ( trunk, svnGitRepoPath )
+    print("Import svn trunk %s\n   to %s:" % ( trunk, svnGitRepoPath ))
     git_cmd.extend( [ svnRepoRoot, tmpGitRepoPath ] )
 
     if verbose:
-        print "git cmd:",
+        print("git cmd:", end=' ')
         for arg in git_cmd:
-            print arg,
-        print
+            print(arg, end=' ')
+        print()
 
-    confirmResp = raw_input( 'Proceed (Y/n)?' )
+    confirmResp = input( 'Proceed (Y/n)?' )
     if len(confirmResp) != 0 and confirmResp != "Y" and confirmResp != "y":
         return
 
@@ -111,7 +111,7 @@ Additional paths for both branches and tags may be added if desired either way.
     args = parser.parse_args( )
 
     if args.module and args.trunk:
-        print 'Please specify either a module name or a trunk path, not both.'    
+        print('Please specify either a module name or a trunk path, not both.')    
         sys.exit()
 
     if args.module:
@@ -119,15 +119,15 @@ Additional paths for both branches and tags may be added if desired either way.
                       tags=args.tags, verbose=args.verbose )
     elif args.trunk is not None or len(args.branches) > 0:
         if not args.name:
-            print 'Please provide a name for git repo'
+            print('Please provide a name for git repo')
             sys.exit()
         if  args.trunk is None:
             args.trunk = args.branches[0]
         importTrunk( args.trunk, args.name, args.branches[1:], args.tags, args.verbose )
     else:
         parser.print_help()
-        print 'Please provide a module name, or one or more branches to import'
+        print('Please provide a module name, or one or more branches to import')
         sys.exit() 
 
-    print "Done."
+    print("Done.")
 

--- a/svnRepo.py
+++ b/svnRepo.py
@@ -37,7 +37,7 @@ class svnRepo( Repo.Repo ):
         (repo_url, repo_tag) = (None, None)
         (packagePath, sep, packageName) = packageSpec.rpartition('/')
 
-        print "FindPackageRelease STUBBED: Need to find packagePath=%s, packageName=%s\n" % (packagePath, packageName)
+        print("FindPackageRelease STUBBED: Need to find packagePath=%s, packageName=%s\n" % (packagePath, packageName))
         return (repo_url, repo_tag)
 
     def GetDefaultPackage( self, package, verbose=False ):
@@ -48,7 +48,7 @@ class svnRepo( Repo.Repo ):
         defaultPackage	= None
         ( svn_url, svn_branch, svn_tag ) = svnGetWorkingBranch()
         if not svn_url:
-            print "Current directory is not an svn working dir!"
+            print("Current directory is not an svn working dir!")
             return None
 
         branchHead	= svn_url
@@ -76,11 +76,11 @@ class svnRepo( Repo.Repo ):
             if branchHead == "":
                 defaultPackage = ""
         if verbose:
-            print "package:        ", package
-            print "defaultPackage: ", defaultPackage
-            print "self._branch:   ", self._branch
-            print "self._url:      ", self._url
-            print "svn_url:        ", svn_url
+            print("package:        ", package)
+            print("defaultPackage: ", defaultPackage)
+            print("self._branch:   ", self._branch)
+            print("self._url:      ", self._url)
+            print("svn_url:        ", svn_url)
         return defaultPackage
 
     def CheckoutRelease( self, buildDir, verbose=False, dryRun=False ):
@@ -88,12 +88,12 @@ class svnRepo( Repo.Repo ):
         if self._tagUrl:
             targetUrl = self._tagUrl
         if verbose or dryRun:
-            print "Checking out: %s\nto build dir: %s ..." % ( targetUrl, buildDir )
+            print("Checking out: %s\nto build dir: %s ..." % ( targetUrl, buildDir ))
         outputPipe = None
         if verbose:
             outputPipe = subprocess.PIPE
         if dryRun:
-            print "CheckoutRelease: --dryRun--"
+            print("CheckoutRelease: --dryRun--")
             return
 
         curDir = os.getcwd()
@@ -135,7 +135,7 @@ class svnRepo( Repo.Repo ):
                 cmdList = [ "svn", "co", targetUrl, buildDir ]
                 subprocess.check_call( cmdList, stdout=outputPipe, stderr=outputPipe )
             except RuntimeError:
-                raise Releaser.BuildError, "CheckoutRelease: svn co failed for %s %s" % ( targetUrl, buildDir )
+                raise Releaser.BuildError("CheckoutRelease: svn co failed for %s %s" % ( targetUrl, buildDir ))
 
     def svnMakeDir( self, svnDir, dryRun=True ):
         try:
@@ -143,22 +143,22 @@ class svnRepo( Repo.Repo ):
                 return
             if svnPathExists( svnDir ):
                 return
-            print "Creating SVN dir:", svnDir
+            print("Creating SVN dir:", svnDir)
             if dryRun:
-                print "svnMakeDir: --dryRun--"
+                print("svnMakeDir: --dryRun--")
                 return
             svnComment = "Creating release directory"
             cmdList = [ "svn", "mkdir", "--parents", svnDir, "-m", svnComment ]
             subprocess.check_call( cmdList )
         except:
-            raise svnError, "Error: svnMakeDir %s\n%s" % ( svnDir, sys.exc_value )
+            raise svnError("Error: svnMakeDir %s\n%s" % ( svnDir, sys.exc_info()[1] ))
 
     def RemoveTag( self, package=None, tag=None ):
         if not package:
             package = self._package
         if not tag:
             tag = self._tag
-        print "RemoveTag: Removing %s release tag %s ..." % ( package, tag )
+        print("RemoveTag: Removing %s release tag %s ..." % ( package, tag ))
 
         tagPath	= "/".join( [ DEF_SVN_TAGS, package, tag ]  )
         svnComment = "Removing unwanted tag %s for %s" % ( tag, package ) 
@@ -166,12 +166,12 @@ class svnRepo( Repo.Repo ):
             cmdList = [ "svn", "ls", tagPath ]
             cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT )
         except:
-            print "tagPath %s not found." % ( tagPath )
+            print("tagPath %s not found." % ( tagPath ))
             return
 
         cmdList = [ "svn", "rm", tagPath, "-m", svnComment ]
         subprocess.check_call( cmdList )
-        print "Successfully removed %s release tag %s." % ( package, tag )
+        print("Successfully removed %s release tag %s." % ( package, tag ))
 
     def TagRelease( self, packagePath=None, release=None, branch=None, message=None, verbose=True, dryRun=False ):
         if branch is None:
@@ -185,15 +185,15 @@ class svnRepo( Repo.Repo ):
         try: # See if tag already exists
             cmdList = [ "svn", "ls", self._tagUrl ]
             cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT )
-            print "%s/%s already tagged." % ( packagePath, release )
+            print("%s/%s already tagged." % ( packagePath, release ))
             return
         except:
             pass
 
         if dryRun:
-            print "--dryRun--",
+            print("--dryRun--", end=' ')
         if verbose:
-            print "Tagging %s ..." % ( self._tagUrl )
+            print("Tagging %s ..." % ( self._tagUrl ))
         if dryRun:
             return
         releaseComment	= "Release %s: " % release

--- a/svn_utils.py
+++ b/svn_utils.py
@@ -14,7 +14,7 @@ def svnPathExists( svnPath, revision=None, debug=False ):
         else:
             repoCmd = [ 'svn', 'ls', svnPath ]
         if debug:
-            print "svnPathExists check_output: %s" % ' '.join( repoCmd )
+            print("svnPathExists check_output: %s" % ' '.join( repoCmd ))
         contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT )
         # No need to check contents
         # If no exception, the path exists
@@ -36,7 +36,7 @@ def svnGetRemoteTags( pathToSvnRepo, verbose=False ):
         pass
     tags = sorted(tags)
     if verbose:
-        print "svnGetRemoteTags: Found %d tags in %s" % ( len(tags), pathToSvnRepo )
+        print("svnGetRemoteTags: Found %d tags in %s" % ( len(tags), pathToSvnRepo ))
     return tags
 
 def svnGetWorkingBranch( debug=False ):
@@ -66,13 +66,13 @@ def svnGetWorkingBranch( debug=False ):
                         break
                 break
 
-    except OSError, e:
+    except OSError as e:
         if debug:
-            print e
+            print(e)
         pass
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if debug:
-            print e
+            print(e)
         pass
     return ( repo_url, repo_branch, repo_tag )
 
@@ -81,7 +81,7 @@ def svnFindPackageRelease( packagePath, tag, debug = False, verbose = False ):
     Returns a tuple: (repo_url, repo_path, repo_tag)
     Returns (None, None, None) on error'''
     if verbose:
-        print "svnFindPackageRelease: Looking for packagePath=%s, tag=%s" % (packagePath, tag)
+        print("svnFindPackageRelease: Looking for packagePath=%s, tag=%s" % (packagePath, tag))
     (repo_url, repo_path, repo_tag) = (None, None, None)
     svn_paths   = []
     if tag:
@@ -112,8 +112,8 @@ def svnFindPackageRelease( packagePath, tag, debug = False, verbose = False ):
             break
     if verbose:
         if repo_url:
-            print "svnFindPackageRelease found %s/%s: url=%s, repo_path=%s, tag=%s" % (packagePath, tag, repo_url, repo_path, repo_tag)
+            print("svnFindPackageRelease found %s/%s: url=%s, repo_path=%s, tag=%s" % (packagePath, tag, repo_url, repo_path, repo_tag))
         else:
-            print "svnFindPackageRelease Error: Cannot find %s/%s" % (packagePath, tag)
+            print("svnFindPackageRelease Error: Cannot find %s/%s" % (packagePath, tag))
     return (repo_url, repo_path, repo_tag)
 

--- a/version_utils.py
+++ b/version_utils.py
@@ -37,7 +37,7 @@ def VersionToRelNumber( version, debug=False ):
     try:
         ver = version
         if debug:
-            print("VersionToRelNumber: %s" % ( ver ))
+            print(("VersionToRelNumber: %s" % ( ver )))
         verMatch = releaseRegExp.search( ver )
         if verMatch:
             ver = verMatch.group(2) + '.' + verMatch.group(3) + verMatch.group(4)
@@ -53,7 +53,7 @@ def VersionToRelNumber( version, debug=False ):
     except:
         pass
     if debug:
-        print("VersionToRelNumber: %s = %f" % ( version, relNumber ))
+        print(("VersionToRelNumber: %s = %f" % ( version, relNumber )))
     return relNumber
 
 def isReleaseCandidate(release):
@@ -131,10 +131,10 @@ def getPkgReleaseList( top, pkgName ):
     Returns a sorted list of releases, most recent first.'''
     # Loop through the directories looking for releases
     if not os.path.isdir( top ):
-        print("getPkgReleaseList Error: top is not a directory: %s\n" % top)
+        print(("getPkgReleaseList Error: top is not a directory: %s\n" % top))
     pkgDir = os.path.join( top, pkgName )
     if not os.path.isdir( pkgDir ):
-        print("getPkgReleaseList Error: %s is not a package under %s\n" % ( pkgName, top ))
+        print(("getPkgReleaseList Error: %s is not a package under %s\n" % ( pkgName, top )))
 
     releaseList = [ ]
     for dirPath, dirs, files in os.walk( pkgDir, topdown=True ):
@@ -182,10 +182,10 @@ def getMacrosFromFile( filePath, macroDict, debug = False, required = False ):
     '''
     if not os.path.isfile( filePath ):
         if required:
-            print("getMacrosFromFile Error: unable to open %s" % filePath) 
+            print(("getMacrosFromFile Error: unable to open %s" % filePath)) 
         return macroDict
     if debug:
-        print("getMacrosFromFile %s: %d versions on entry" % ( filePath, len(macroDict) ))
+        print(("getMacrosFromFile %s: %d versions on entry" % ( filePath, len(macroDict) )))
     in_file = open( filePath, "r" )
     for line in in_file:
         line = line.strip()
@@ -215,7 +215,7 @@ def getMacrosFromFile( filePath, macroDict, debug = False, required = False ):
             macroValue = macroMatch.group(2)
             if macroName and macroValue:
                 if debug:
-                    print("getMacrosFromFile: %s = %s" % ( macroName, macroValue ))
+                    print(("getMacrosFromFile: %s = %s" % ( macroName, macroValue )))
                 macroDict[ macroName ] = macroValue
                 break
 
@@ -225,7 +225,7 @@ def getMacrosFromFile( filePath, macroDict, debug = False, required = False ):
         macroDict[macroName] = expandMacros( macroValue, macroDict )
 
     if debug:
-        print("getMacrosFromFile %s: %d versions on exit" % ( filePath, len(macroDict) ))
+        print(("getMacrosFromFile %s: %d versions on exit" % ( filePath, len(macroDict) )))
     return macroDict
 
 def getEpicsPkgDependents( topDir, debug=False ):
@@ -237,7 +237,7 @@ def getEpicsPkgDependents( topDir, debug=False ):
     # Get the base and dependent modules from RELEASE files
     releaseFile = os.path.join( topDir, "configure", "RELEASE" )
     if debug:
-        print("getEpicsPkgDependents: Checking release file: %s" % ( releaseFile ))
+        print(("getEpicsPkgDependents: Checking release file: %s" % ( releaseFile )))
     if os.path.isfile( releaseFile ):
         macroDict = getMacrosFromFile( releaseFile, macroDict, debug=debug )
 
@@ -262,7 +262,7 @@ def getEpicsPkgDependents( topDir, debug=False ):
             pkgVersion = '/'.join( macroValue.split('/')[-3:] )
         if pkgName and pkgVersion:
             if debug:
-                print("getEpicsPkgDependents: %s = %s" % ( pkgName, pkgVersion ))
+                print(("getEpicsPkgDependents: %s = %s" % ( pkgName, pkgVersion )))
             pkgDependents[ pkgName ] = pkgVersion
 
     if "base" in pkgDependents:
@@ -370,7 +370,7 @@ def ExpandPackagePath( topDir, pkgSpec, base=None, debug=False ):
     # See if it exists
     if not os.path.isdir( pkgPath ):
         if debug:
-            print("ExpandPackagePath: %s not found" % ( pkgPath ))
+            print(("ExpandPackagePath: %s not found" % ( pkgPath )))
         return []
 
     # See if this is a screens release
@@ -379,7 +379,7 @@ def ExpandPackagePath( topDir, pkgSpec, base=None, debug=False ):
         screenArg   = True
 
     if debug:
-        print("ExpandPackagePath: Expanding %s ..." % ( pkgPath ))
+        print(("ExpandPackagePath: Expanding %s ..." % ( pkgPath )))
 
     selectedReleases = [ ]
     if isReleaseCandidate( os.path.split( pkgPath )[-1] ):
@@ -413,7 +413,7 @@ def ExpandPackagePath( topDir, pkgSpec, base=None, debug=False ):
                 buildPath = os.path.join( release, "build" )
                 if os.path.isfile( verPath ) or os.path.isdir( buildPath ):
                     if debug:
-                        print("ExpandPackagePath: Found ", release)
+                        print(("ExpandPackagePath: Found ", release))
                     releases += [ release ]
 
             if len( releases ) == 0:
@@ -436,6 +436,6 @@ def ExpandPackagePath( topDir, pkgSpec, base=None, debug=False ):
                 selectedReleases += [ releaseSet[ release ] ]
 
     if debug:
-        print("ExpandPackagePath Selected Releases: %s" % selectedReleases )
+        print(("ExpandPackagePath Selected Releases: %s" % selectedReleases ))
     return selectedReleases
 

--- a/version_utils.py
+++ b/version_utils.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
-#from __future__ import print_function
+#!/usr/bin/env python3
 import os
 import re
 import sys
 import glob
-#import pprint
 import subprocess
 from pkgNamesToMacroNames import *
 #

--- a/whatsAffected.py
+++ b/whatsAffected.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #==============================================================
 #
 #  whatsAffected.py:  What are the modules that are affected if we make changes to one module

--- a/whatsAffected.py
+++ b/whatsAffected.py
@@ -25,7 +25,7 @@ def parseModulesTextFile(modules_txt_path):
             continue;
         parts = li.split()
         if len(parts) != 2:
-            print "Skipping incorrectly formatted line", li
+            print("Skipping incorrectly formatted line", li)
             continue
         moduleName=parts[0]
         moduleVersion=parts[1]
@@ -82,21 +82,21 @@ def assessImpact(modules_txt_path, module_being_changed):
     '''Determine the modules that depend on the module being changed'''
     moduleName2Version = parseModulesTextFile(modules_txt_path)
     module2Dependencies = {}
-    for (moduleName, moduleVersion) in moduleName2Version.iteritems():
+    for (moduleName, moduleVersion) in moduleName2Version.items():
         path_to_configure_release = os.path.join(moduleName, moduleVersion, 'configure', 'RELEASE')
         dependencies = determineModuleDependenciesFromConfigureRelease(path_to_configure_release)
         module2Dependencies[moduleName] = [x[0] for x in dependencies]
-    impacted_modules = [x[0] for x in module2Dependencies.iteritems() if module_being_changed in x[1]]
+    impacted_modules = [x[0] for x in module2Dependencies.items() if module_being_changed in x[1]]
     if impacted_modules:
-        print "The module", module_being_changed, "directly impacts these modules", ", ".join(sorted(impacted_modules))
+        print("The module", module_being_changed, "directly impacts these modules", ", ".join(sorted(impacted_modules)))
         # Compute the impact recursively
         visited, stack = set(), [module_being_changed]
         while stack:
             moduleName = stack.pop()
             if moduleName not in visited:
                 visited.add(moduleName)
-                stack.extend([x[0] for x in module2Dependencies.iteritems() if moduleName in x[1]])
-        print "The module", module_being_changed, "recursively impacts these modules", ", ".join(sorted(visited))
+                stack.extend([x[0] for x in module2Dependencies.items() if moduleName in x[1]])
+        print("The module", module_being_changed, "recursively impacts these modules", ", ".join(sorted(visited)))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='''For the modules specified in the input moduleslist.txt file, determine their dependencies and use this to assess the impact of changing one module to a newer version''')


### PR DESCRIPTION
This PR adds support for Python 3. Since this is somewhat of a breaking change, the major version number should probably be bumped (so eco_tools 3.0, or something)

Notable changes
* Converted all python files to Python 3 with 2to3. This seems to work completely out of the box, barring a single `decode()`
* Removed cvs2git functionality. The backing library only supports Python 2. If anyone needs this functionality, they should just use an older version of eco_tools (that's my rationale at least). 
* Updated shebang lines to point to `python3`