### PR TITLE
Use universal_newlines instead of text in subprocess calls

### DIFF
--- a/Releaser.py
+++ b/Releaser.py
@@ -221,7 +221,7 @@ class Releaser(object):
         sys.stdout.flush()
         userId  = os.geteuid()
         groupId = -1
-        groups  = subprocess.check_output( [ "id" ], text=True )
+        groups  = subprocess.check_output( [ "id" ], universal_newlines=True )
         if self._grpOwner is not None:
             if re.search( groups, self._grpOwner ):
                 groupId = grp.getgrname(self._grpOwner).gr_gid 
@@ -291,7 +291,7 @@ class Releaser(object):
         '''Returns True if module has built for any architecture.'''
         hasBuilt = False
         try:
-            findOutput = subprocess.check_output( [ "find", self._ReleasePath, "-name", ".is_built" ], text=True ).splitlines()
+            findOutput = subprocess.check_output( [ "find", self._ReleasePath, "-name", ".is_built" ], universal_newlines=True ).splitlines()
             if len(findOutput) > 0:
                 hasBuilt = True
         except:
@@ -505,7 +505,7 @@ class Releaser(object):
                 return -1
             # Canonicalize installTop
             cmdList = [ "readlink", "-e", installTop ]
-            cmdOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+            cmdOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
             if len(cmdOutput) == 1:
                 installTop = cmdOutput[0]
 

--- a/cram_utils.py
+++ b/cram_utils.py
@@ -38,7 +38,7 @@ def determineCramAppType():
                                     '--title', "Choose the type of software application",
                                     '--column="Type"', '--column="Description"']
                                     + list(reduce(lambda x, y: x + y, list(appTypes.items()))),
-                                    text=True,
+                                    universal_newlines=True,
                                     ).strip()
     return apptype
 

--- a/cvs2git_utils.py
+++ b/cvs2git_utils.py
@@ -119,7 +119,7 @@ def importHistoryFromCVS(tpath, gitRepoPath, CVSpackageLocation ):
     print("Done importing CVS dump into git repo")
 
     # If cvs2git created a TAG.FIXUP branch, delete it
-    cmdOutput = subprocess.check_output( [ 'git', 'branch', '-l' ], text=True).splitlines()
+    cmdOutput = subprocess.check_output( [ 'git', 'branch', '-l' ], universal_newlines=True).splitlines()
     for line in cmdOutput:
         if 'TAG.FIXUP' in line:
             subprocess.call(['git', 'branch', '-D', 'TAG.FIXUP'])

--- a/cvs_utils.py
+++ b/cvs_utils.py
@@ -16,7 +16,7 @@ def cvsPathExists( cvsPath, revision=None, debug=False ):
             repoCmd = [ 'cvs', 'ls', cvsPath ]
         if debug:
             print("cvsPathExists check_output: %s" % ' '.join( repoCmd ))
-        contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT, text=True )
+        contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT, universal_newlines=True )
         # No need to check contents
         # If no exception, the path exists
         return True
@@ -54,7 +54,7 @@ def cvsGetWorkingBranch( debug=False ):
     repo_tag    = None
     try:
         repoCmd = [ 'cvs', 'info', '.' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
         statusLines = statusInfo.splitlines()
         for line in statusLines:
             if line is None:

--- a/epics-checkout.py
+++ b/epics-checkout.py
@@ -354,7 +354,7 @@ def initGitBareRepo( options ):
     showStatusZenity = False
     zenityVersion = None
     try:
-        zenityVersion = subprocess.check_output(["zenity", "--version"], text=True).strip()
+        zenityVersion = subprocess.check_output(["zenity", "--version"], universal_newlines=True).strip()
     except:
         print( "zenity not found!" )
         return
@@ -366,7 +366,7 @@ def initGitBareRepo( options ):
         packageSpec = options.module
     else: # TODO: Handle zenityVersion None
         # Ask the user for the name of the package
-        packageSpec = subprocess.check_output(["zenity", "--entry", "--title", "Package Name", "--text", "Please enter the name of the package"], text=True).strip()
+        packageSpec = subprocess.check_output(["zenity", "--entry", "--title", "Package Name", "--text", "Please enter the name of the package"], universal_newlines=True).strip()
         showStatusZenity = True
     packageName = os.path.split(packageSpec)[1]
 
@@ -390,7 +390,7 @@ def initGitBareRepo( options ):
     else:
         # Ask the use where the upstream bare repo is to be created
         showStatusZenity = True
-        bareRepoParentFolder = subprocess.check_output(["zenity", "--file-selection", "--title", "Please choose the parent folder where you want to create the bare repo", "--directory", "--filename="+gitRoot], text=True).strip()
+        bareRepoParentFolder = subprocess.check_output(["zenity", "--file-selection", "--title", "Please choose the parent folder where you want to create the bare repo", "--directory", "--filename="+gitRoot], universal_newlines=True).strip()
 
 
     gitRepoPath = os.path.join( bareRepoParentFolder, packageName+".git" )

--- a/epics-versions.py
+++ b/epics-versions.py
@@ -119,14 +119,14 @@ def ReportDependents( module, pkgDependents, wide=False, recurse=True ):
 def ReportRelease( pkgPath, release, priorModule, opt ):
     ''' Get the module and version from the release string. '''
     cmdList = [ "readlink", "-e", release ]
-    cmdOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+    cmdOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
     if len(cmdOutput) == 1:
         release = str(cmdOutput[0])
     ( relPath, moduleVersion ) = os.path.split( release )
     # Simplify the module path by removing the default module release
     # portion of the path
     cmdList = [ "readlink", "-e", pkgPath ]
-    cmdOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+    cmdOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
     if len(cmdOutput) == 1:
         pkgPath = str(cmdOutput[0])
     #relPath = relPath.replace( "slac.stanford.edu", "slac" )
@@ -422,7 +422,8 @@ except KeyboardInterrupt:
 except SystemExit:
     raise
 
-except:
+except Exception as e:
+    raise e
     if debugScript:
         traceback.print_tb(sys.exc_info()[2])
     print("%s exited with ERROR:\n%s\n" % ( sys.argv[0], sys.exc_info()[1] ))

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -53,14 +53,14 @@ class gitRepo( Repo.Repo ):
                 os.chdir( buildDir )
                 curSha = None
                 cmdList = [ "git", "rev-parse", "HEAD" ]
-                gitOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+                gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
                 if len(gitOutput) == 1:
                     curSha = gitOutput[0]
 
                 # Get the tag SHA
                 tagSha = None
                 cmdList = [ "git", "rev-parse", self._tag ]
-                gitOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+                gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
                 if len(gitOutput) == 1:
                     tagSha = gitOutput[0]
 
@@ -101,7 +101,7 @@ class gitRepo( Repo.Repo ):
         branchSha = None
         try:
             cmdList = [ "git", "show-ref", '-s', 'refs/heads/%s' % self._tag ]
-            gitOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+            gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
             if len(gitOutput) == 1:
                 branchSha = gitOutput[0]
         except subprocess.CalledProcessError as e:

--- a/git_utils.py
+++ b/git_utils.py
@@ -134,7 +134,7 @@ def git_check_output( gitCommand, gitDir=None, debug=False, *args, ** kwargs ):
     if debug:
         print("git_check_output running: %s" % ' '.join( cmdList ))
 
-    git_output = subprocess.check_output( cmdList, *args, **kwargs, text=True )
+    git_output = subprocess.check_output( cmdList, *args, **kwargs, universal_newlines=True )
 
     if debug:
         print(git_output)
@@ -146,7 +146,7 @@ def gitGetRemoteFile( url, refName, filePath, debug = False ):
     fileContents = None
     try:
         commitSpec = refName + ':' + filePath
-        fileContents = subprocess.check_output( [ 'git', '--git-dir=%s' % url, 'show', commitSpec ], stderr=subprocess.STDOUT, text=True )
+        fileContents = subprocess.check_output( [ 'git', '--git-dir=%s' % url, 'show', commitSpec ], stderr=subprocess.STDOUT, universal_newlines=True )
     except OSError as e:
         if debug:
             print(e)
@@ -165,7 +165,7 @@ def gitGetRemoteTags( url, debug = False, verbose = False ):
     try:
         if verbose:
             print("gitGetRemoteTags running: git ls-remote %s" % url)
-        statusInfo = subprocess.check_output( [ 'git', 'ls-remote', url ], stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( [ 'git', 'ls-remote', url ], stderr=subprocess.STDOUT, universal_newlines=True )
         for line in statusInfo.splitlines():
             if line is None:
                 break
@@ -228,7 +228,7 @@ def gitGetTagSha( tag ):
     try:
         # Get the tagSha
         cmdList = [ "git", "show-ref", tag ]
-        gitOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+        gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
         if len(gitOutput) == 1:
             tagSha = gitOutput[0].split()[0]
     except:
@@ -348,13 +348,13 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
     repo_tag    = None
     try:
         repoCmd = [ 'git', 'symbolic-ref', 'HEAD' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
         statusLines = statusInfo.splitlines()
         if len(statusLines) > 0 and statusLines[0].startswith( 'refs/heads/' ):
             repo_branch = statusLines[0].split('/')[2]
 
         repoCmd = [ 'git', 'remote', '-v' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
         statusLines = statusInfo.splitlines()
         for line in statusLines:
             if line is None:
@@ -375,7 +375,7 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
                 repo_url = repoPath
 
         # See if HEAD corresponds to any tags
-        statusInfo = subprocess.check_output( [ 'git', 'name-rev', '--name-only', '--tags', 'HEAD' ], stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( [ 'git', 'name-rev', '--name-only', '--tags', 'HEAD' ], stderr=subprocess.STDOUT, universal_newlines=True )
         statusLines = statusInfo.splitlines()
         if len(statusLines) > 0:
             # Just grab the first tag that matches

--- a/site_utils.py
+++ b/site_utils.py
@@ -96,7 +96,7 @@ def determine_epics_host_arch():
             epicsHostArchPath	= os.path.join(	epics_site_top, 'base',
                                                 epics_base_ver, 'startup', 'EpicsHostArch' )
             if os.path.isfile( epicsHostArchPath ):
-                cmdOutput = subprocess.check_output( [ epicsHostArchPath ], text=True ).splitlines()
+                cmdOutput = subprocess.check_output( [ epicsHostArchPath ], universal_newlines=True ).splitlines()
                 if len(cmdOutput) == 1:
                     epics_host_arch = cmdOutput[0].decode()
 

--- a/svnIocToGit.py
+++ b/svnIocToGit.py
@@ -90,7 +90,7 @@ def importTrunk( trunk, name, gitUrl, branches=[], tags=[], verbose=False, batch
     # a comment, the tagger, and the tag timestamp.
     curDir = os.getcwd()
     os.chdir(tmpGitRepoPath)
-    output = subprocess.check_output([ "git", "branch", "-a" ], text=True)
+    output = subprocess.check_output([ "git", "branch", "-a" ], universal_newlines=True)
     lines  = output.splitlines()
     for line in lines:
         remoteTag = re.search( r"remotes/tags/([^@]*)$", line )

--- a/svnModuleToGit.py
+++ b/svnModuleToGit.py
@@ -82,7 +82,7 @@ def importTrunk( trunk, name, gitRoot, branches=[], tags=[], verbose=False ):
     # a comment, the tagger, and the tag timestamp.
     curDir = os.getcwd()
     os.chdir(tmpGitRepoPath)
-    output = subprocess.check_output([ "git", "branch", "-a" ], text=True)
+    output = subprocess.check_output([ "git", "branch", "-a" ], universal_newlines=True)
     lines  = output.splitlines()
     for line in lines:
         remoteTag = re.search( r"remotes/tags/([^@]*)$", line )

--- a/svnRepo.py
+++ b/svnRepo.py
@@ -103,7 +103,7 @@ class svnRepo( Repo.Repo ):
             # See if the tag is already checked out
             curTag = None
             cmdList = [ "svn", "info", "." ]
-            cmdOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+            cmdOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
             if len(cmdOutput) == 1:
                 curUrl = cmdOutput[0]
                 if curUrl == targetUrl:
@@ -121,7 +121,7 @@ class svnRepo( Repo.Repo ):
                         raise
 
                     cmdList = [ "svn", "update", "." ]
-                    cmdOutput = subprocess.check_output( cmdList, text=True ).splitlines()
+                    cmdOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
                     self.execute("/bin/rm -f %s" % ( self.built_cookie_path() ))
                     os.chdir( curDir )
                     return
@@ -164,7 +164,7 @@ class svnRepo( Repo.Repo ):
         svnComment = "Removing unwanted tag %s for %s" % ( tag, package ) 
         try:
             cmdList = [ "svn", "ls", tagPath ]
-            cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT, text=True )
+            cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT, universal_newlines=True )
         except:
             print("tagPath %s not found." % ( tagPath ))
             return
@@ -184,7 +184,7 @@ class svnRepo( Repo.Repo ):
 
         try: # See if tag already exists
             cmdList = [ "svn", "ls", self._tagUrl ]
-            cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT, text=True )
+            cmdOutput = subprocess.check_output( cmdList, stderr=subprocess.STDOUT, universal_newlines=True )
             print("%s/%s already tagged." % ( packagePath, release ))
             return
         except:

--- a/svn_utils.py
+++ b/svn_utils.py
@@ -15,7 +15,7 @@ def svnPathExists( svnPath, revision=None, debug=False ):
             repoCmd = [ 'svn', 'ls', svnPath ]
         if debug:
             print("svnPathExists check_output: %s" % ' '.join( repoCmd ))
-        contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT, text=True )
+        contents = subprocess.check_output( repoCmd, stderr = subprocess.STDOUT, universal_newlines=True )
         # No need to check contents
         # If no exception, the path exists
         return True
@@ -30,7 +30,7 @@ def svnGetRemoteTags( pathToSvnRepo, verbose=False ):
     tagsPath = tagsPath.replace( "trunk", "tags" )
     tagsPath = tagsPath.replace( "/current", "" )
     try:
-        tags = subprocess.check_output(["svn", "ls", tagsPath ], text=True ).splitlines()
+        tags = subprocess.check_output(["svn", "ls", tagsPath ], universal_newlines=True ).splitlines()
         tags = [ tag.replace("/", "") for tag in tags ]
     except:
         pass
@@ -50,7 +50,7 @@ def svnGetWorkingBranch( debug=False ):
     repo_tag    = None
     try:
         repoCmd = [ 'svn', 'info', '.' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, text=True )
+        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
         statusLines = statusInfo.splitlines()
         for line in statusLines:
             if line is None:


### PR DESCRIPTION
The `text` key parameter was added in python 3.7 as a more readable alternative to `universal_newlines`. Unfortunately, when you install Python 3 on rhel7, you get python 3.6.8, so we need to use `universal_newlines` instead.

Tested on dev-epicsgw & aird-b50-srv01