### PR TITLE
Robust build support

### DIFF
--- a/Releaser.py
+++ b/Releaser.py
@@ -237,8 +237,9 @@ class Releaser(object):
         for dirPath, dirs, files in os.walk(dir):
             pathStatus = os.stat( dirPath )
             dirName = os.path.split( dirPath )[-1]
+            isRepoPath = '.git' in dirPath or '.svn' in dirPath or 'CVS' in dirPath
+            # Don't try to fix directories you don't own
             if userId == pathStatus.st_uid:
-                isRepoPath = '.git' in dirPath or '.svn' in dirPath or 'CVS' in dirPath
                 if dirName == 'edl' or dirName.endswith( 'Screens' ):
                     # Leave edl directories read-only to avoid edm replacing release screens
                     os.chmod( dirPath, pathStatus.st_mode & ~modeUserGroupWrite )
@@ -246,17 +247,21 @@ class Releaser(object):
                     os.chmod( dirPath, pathStatus.st_mode | dirModeAllow )
                 if groupId >= 0 and groupId != pathStatus.st_gid:
                     os.chown( dirPath, -1, groupId )
-                for fileName in files:
-                    filePath   = os.path.join( dirPath, fileName )
-                    pathStatus = os.lstat( filePath )
-                    if os.path.islink(filePath) and hasattr(os, 'lchmod' ):
-                        os.lchmod( filePath, pathStatus.st_mode & ~modeUserGroupWrite )
-                    elif isRepoPath:
-                        os.chmod( filePath, pathStatus.st_mode | modeUserGroupWrite )
-                    else:
-                        os.chmod( filePath, pathStatus.st_mode & ~modeUserGroupWrite )
-                    if groupId >= 0 and groupId != pathStatus.st_gid:
-                        os.lchown( filePath, -1, groupId )
+
+            for fileName in files:
+                filePath   = os.path.join( dirPath, fileName )
+                pathStatus = os.lstat( filePath )
+                # Don't try to fix files you don't own
+                if userId != pathStatus.st_uid:
+                    continue
+                if os.path.islink(filePath) and hasattr(os, 'lchmod' ):
+                    os.lchmod( filePath, pathStatus.st_mode & ~modeUserGroupWrite )
+                elif isRepoPath:
+                    os.chmod( filePath, pathStatus.st_mode | modeUserGroupWrite )
+                else:
+                    os.chmod( filePath, pathStatus.st_mode & ~modeUserGroupWrite )
+                if groupId >= 0 and groupId != pathStatus.st_gid:
+                    os.lchown( filePath, -1, groupId )
 
     def getCookieJarPath( self ):
         if self._CookieJarPath:

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -48,9 +48,14 @@ class gitRepo( Repo.Repo ):
         curDir = os.getcwd()
         if os.path.isdir( os.path.join( buildDir, '.git' ) ):
             try:
+                os.chdir( buildDir )
+                # Since it already exists, it may have been created by someone else.
+                # Add it as a safe directory to avoid checkout errors
+                cmdList = [ "git", "config", "--global", "--add", "safe.directory", buildDir ]
+                gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
+
                 # See if the tag is already checked out
                 # Get the current HEAD SHA
-                os.chdir( buildDir )
                 curSha = None
                 cmdList = [ "git", "rev-parse", "HEAD" ]
                 gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()


### PR DESCRIPTION
These changes make eco_tools utilities less likely to fail if a release repo was originally created by a different user.
chmod operations are now only attempted for files and directories owned by current user.
Also, we add a global config option safe.directory for these repos created by a different user.