### PR TITLE
Add --url option to epics-release

### DIFF
--- a/epics-release.py
+++ b/epics-release.py
@@ -179,7 +179,7 @@ try:
     parser.add_option(	"-r", "-R", "--release", dest="release",
                         help="release version string, ex. -r R1.2.3-0.1.0" )
     parser.add_option(	"-u", "--url", dest="repo_url",
-                        help="repo URL, ex. -u git@github.com:/slac-epics/ADCore.git" )
+                        help="repo URL, ex. -u git@github.com:slac-epics/ADCore.git" )
     parser.add_option(	"-m", "--message", dest="message",
                         help="release message in quotes"	)
     parser.add_option(	"-v", "--verbose", dest="verbose", action="store_true",

--- a/epics-release.py
+++ b/epics-release.py
@@ -178,6 +178,8 @@ try:
                             keeptmp		= False	)
     parser.add_option(	"-r", "-R", "--release", dest="release",
                         help="release version string, ex. -r R1.2.3-0.1.0" )
+    parser.add_option(	"-u", "--url", dest="repo_url",
+                        help="repo URL, ex. -u git@github.com:/slac-epics/ADCore.git" )
     parser.add_option(	"-m", "--message", dest="message",
                         help="release message in quotes"	)
     parser.add_option(	"-v", "--verbose", dest="verbose", action="store_true",
@@ -233,7 +235,7 @@ try:
     packagePath  = None
 
     # See if this is a git working dir
-    ( git_url, git_branch, git_tag ) = gitGetWorkingBranch()
+    ( git_url, git_branch, git_tag ) = gitGetWorkingBranch( repo_url=opt.repo_url, verbose=opt.verbose )
     repo_tag = git_tag
 
     if git_url:

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -62,12 +62,14 @@ class gitRepo( Repo.Repo ):
                 if len(gitOutput) == 1:
                     curSha = gitOutput[0]
 
-                # Get the tag SHA
+                # Get the commit for the tag
                 tagSha = None
-                cmdList = [ "git", "rev-parse", self._tag ]
+                cmdList = [ "git", "show-ref", "-d", self._tag ]
                 gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
-                if len(gitOutput) == 1:
-                    tagSha = gitOutput[0]
+                if len(gitOutput) == 2:
+                    tag_commit_info = gitOutput[1].split()
+                    if len(tag_commit_info) == 2:
+                        tagSha = tag_commit_info[0]
 
                 # If they match, it's already checked out!
                 if curSha == tagSha:
@@ -116,8 +118,8 @@ class gitRepo( Repo.Repo ):
             # Refresh the tags
             # TODO: May fail if git repo is read-only
             if verbose:
-                print("CheckoutRelease running: git fetch origin refs/tags/%s" % self._tag)
-            cmdList = [ "git", "fetch", "origin", "refs/tags/" + self._tag ]
+                print("CheckoutRelease running: git fetch %s refs/tags/%s" % (self._url, self._tag))
+            cmdList = [ "git", "fetch", self._url, "refs/tags/" + self._tag ]
             subprocess.check_call( cmdList, stdout=outputPipe, stderr=outputPipe )
 
             tagSha = gitGetTagSha( self._tag )
@@ -170,7 +172,7 @@ class gitRepo( Repo.Repo ):
         if verbose:
             print("\nRemoving %s release tag %s ..." % ( package, tag ))
         subprocess.check_call( [ "git", "tag", "-d", tag ] )
-        subprocess.check_call( [ 'git', 'push', '--delete', 'origin', tag ] )
+        subprocess.check_call( [ 'git', 'push', '--delete', self._url, tag ] )
         print("Successfully removed %s release tag %s." % ( package, tag ))
 
     def PushBranch( self, branchName=None, verbose=True, dryRun=False ):
@@ -186,7 +188,7 @@ class gitRepo( Repo.Repo ):
             return
         if verbose:
             print("Pushing branch %s ..." % ( branchName ))
-        subprocess.check_call( [ 'git', 'push', 'origin', branchName ] )
+        subprocess.check_call( [ 'git', 'push', self._url, branchName ] )
 
     def PushTag( self, release, verbose=True, dryRun=False ):
         if dryRun:
@@ -195,7 +197,7 @@ class gitRepo( Repo.Repo ):
 
         if verbose:
             print("Pushing tag %s ..." % ( release ))
-        subprocess.check_call( [ 'git', 'push', 'origin', release ] )
+        subprocess.check_call( [ 'git', 'push', self._url, release ] )
 
     def TagRelease( self, packagePath=None, release=None, branch=None, message="", verbose=True, dryRun=False ):
         if release is None:
@@ -209,6 +211,6 @@ class gitRepo( Repo.Repo ):
         comment = "Release %s/%s: %s" % ( packagePath, release, message )
         cmdList = [ "git", "tag", release, 'HEAD', "-m", comment ]
         subprocess.check_call( cmdList )
-        subprocess.check_call( [ 'git', 'push', '-u', 'origin' ] )
-        subprocess.check_call( [ 'git', 'push', 'origin', release ] )
+        subprocess.check_call( [ 'git', 'push', '-u', self._url, ] )
+        subprocess.check_call( [ 'git', 'push', self._url, release ] )
 

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -26,7 +26,7 @@ class gitRepo( Repo.Repo ):
         return strRep
 
     def GetWorkingBranch( self ):
-        return gitGetWorkingBranch()
+        return gitGetWorkingBranch(repo_url=self._url)
 
     def GetDefaultPackage( self, package, verbose=False ):
         return package

--- a/git_utils.py
+++ b/git_utils.py
@@ -343,12 +343,11 @@ def createBranchFromTag( tag, branchName ):
     subprocess.check_call(['git', 'checkout', '-q', tag])
     subprocess.check_call(['git', 'checkout', '-b', branchName])
 
-def gitGetWorkingBranch( debug = False, verbose = False ):
+def gitGetWorkingBranch( repo_url = None, debug = False, verbose = False ):
     '''See if the current directory is the top of an git working directory.
     Returns a 3-tuple of ( url, branch, tag ), ( None, None, None ) on error.
     For a valid git working dir, url must be a valid string, branch is the branch name or None if detached,
     tag is either None or a tag name if HEAD refers to a tag name.'''
-    repo_url    = None
     repo_branch = None
     repo_tag    = None
     try:
@@ -358,26 +357,27 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
         if len(statusLines) > 0 and statusLines[0].startswith( 'refs/heads/' ):
             repo_branch = statusLines[0].split('/')[2]
 
-        repoCmd = [ 'git', 'remote', '-v' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
-        statusLines = statusInfo.splitlines()
-        for line in statusLines:
-            if line is None:
-                break
-            tokens = line.split()
-            if tokens[0] == 'origin':			# Use remote 'origin' if found
-                repo_url = tokens[1]
-                break
-            if tokens[0].find('origin') >= 0:	# Backup is last remote containing 'origin'
-                repo_url = tokens[1]
-            if repo_url is None:				# If all else fails just use first remote
-                repo_url = tokens[1]
+        if not repo_url:
+            repoCmd = [ 'git', 'remote', '-v' ]
+            statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
+            statusLines = statusInfo.splitlines()
+            for line in statusLines:
+                if line is None:
+                    break
+                tokens = line.split()
+                if tokens[0] == 'origin':			# Use remote 'origin' if found
+                    repo_url = tokens[1]
+                    break
+                if tokens[0].find('origin') >= 0:	# Backup is last remote containing 'origin'
+                    repo_url = tokens[1]
+                if repo_url is None:				# If all else fails just use first remote
+                    repo_url = tokens[1]
 
-        if repo_url:
-            # Remove any trailing path separator
-            ( repoPath, repoPkg ) = os.path.split( repo_url )
-            if not repoPkg:
-                repo_url = repoPath
+            if repo_url:
+                # Remove any trailing path separator
+                ( repoPath, repoPkg ) = os.path.split( repo_url )
+                if not repoPkg:
+                    repo_url = repoPath
 
         # See if HEAD corresponds to any tags
         statusInfo = subprocess.check_output( [ 'git', 'name-rev', '--name-only', '--tags', 'HEAD' ], stderr=subprocess.STDOUT, universal_newlines=True )


### PR DESCRIPTION
Allows specifying the git repo URL on the epics-release command line as an option.
This is a quick fix for epics-release not working properly w/ github.com master repos.