### PR TITLE
Add ck in epics-release for MY_MODULES still defined.

### DIFF
--- a/epics-release.py
+++ b/epics-release.py
@@ -111,6 +111,10 @@ def ValidateArgs( repo, packageSpec, opt ):
     if not re.match( r"(\S*R\d+([\-\.]\d+)-\d+\.\d+\.\d+?)|(\S*R\d+[\.\-]\d+([\-\.]\d+)?)", opt.release ):
         raise ValidateError("%s is an invalid release tag: Must be R[<orig_release>-]<major>.<minor>.<bugfix>" % opt.release)
 
+    # Check if MY_MODULES is still defined
+    if doesPkgDefineMacro( 'MY_MODULES' ):
+        raise ValidateError("MY_MODULES is still defined!  Release tags must not define MY_MODULES.")
+
     if not opt.noTag and repo_tag != opt.release:
         # validate release message
         if not opt.message:

--- a/version_utils.py
+++ b/version_utils.py
@@ -330,6 +330,27 @@ def doesPkgNeedMacro( macroName ):
         needsMacro = False
     return needsMacro
 
+def doesPkgDefineMacro( macroName ):
+    '''
+    Check if configure/RELEASE* files define a particular macro
+    '''
+    if not macroName or len(macroName) == 0:
+        return False
+    # TODO: Check all configure/RELEASE* files
+    definesMacro = False
+    definesMacroRegExp = re.compile( r'^%s\s*=\s*\S' % macroName )
+    for filename in [ 'RELEASE', 'RELEASE.local' ]:
+        configFilePath = os.path.join( 'configure', filename )
+        if not os.path.isfile( configFilePath ):
+            continue
+        configFile = open( configFilePath, 'r')
+        for line in configFile:
+            # Check if this macro is defined
+            if  definesMacroRegExp.search( line ):
+                definesMacro = True
+
+    return definesMacro
+
 def ExpandPackagePath( topDir, pkgSpec, base=None, debug=False ):
     '''Takes a topDir directory path and looks for packages which match the pkgSpec.
     The pkgSpec can be "modules", "ioc", "ioc/common", "ioc/$AREA", "$MODULE_NAME",


### PR DESCRIPTION
If a release is created that leaves a developer specific path for MY_MODULES, it can create conflicts later when MY_MODULES needs to be set to some other developer path in an IOC or module that depends on that release.
Thus, I added a test in epics-release to check for any define of MY_MODULES before allowing the release to be built.