### PR TITLE
GitHub support

### DIFF
--- a/Releaser.py
+++ b/Releaser.py
@@ -16,6 +16,8 @@ from svn_utils import *
 from site_utils import *
 from version_utils import *
 
+defaultPackageTypeToModule  = True
+
 def makeDirsWritable( dirPathTop ):
     userId  = os.geteuid()
     for dirPath, dirs, files in os.walk(dirPathTop):
@@ -465,8 +467,32 @@ class Releaser(object):
                 print("InstallPackage Error: Need valid installTop to determine installDir!")
                 return status
 
+            # Is Package an extension?
+            if not installTop:
+                if		self._packagePath.find('extensions') >= 0 \
+                     or	self._repo.GetUrl().find('extensions') >= 0:
+                    installTop = os.path.join( epics_site_top, 'extensions' ) 
+
+            # Is Package an IOC?
+            if		installTop is None \
+                and	(	os.path.split( self._packagePath )[0].startswith('ioc') \
+                    or  self._repo.GetUrl().find('ioc-') >= 0 ):
+                # Package is an IOC
+                # TODO: If github repo uses ioc-foo-bar, we need to use installDir ioc/foo/bar
+                topVariants = [ epics_site_top ]
+                for topVariant in defEpicsTopVariants:
+                    topVariants.append( os.path.join( epics_site_top, topVariant ) )
+                for topVariant in topVariants:
+                    epics_ioc_top = os.path.join( topVariant, os.path.split(self._packagePath)[0] )
+                    if os.path.isdir( epics_ioc_top ):
+                        installTop = os.path.join( topVariant, self._packagePath )
+                        if not os.path.isdir( installTop ):
+                            os.makedirs( installTop, 0o775 )
+                        break
+
             # Is Package a module?
             if	os.path.split( self._packagePath )[0] == 'modules' \
+            or  defaultPackageTypeToModule \
             or  self._repo.GetUrl().find('modules') >= 0:
                 # Package is a module
                 if installTop is not None:
@@ -482,27 +508,6 @@ class Releaser(object):
                         print("InstallPackage Error: Unable to determine EPICS modules installTop!")
                         return status
                     installTop = epics_modules_top
-
-            # Is Package an extension?
-            if not installTop:
-                if		self._packagePath.find('extensions') >= 0 \
-                     or	self._repo.GetUrl().find('extensions') >= 0:
-                    installTop = os.path.join( epics_site_top, 'extensions' ) 
-
-            # Is Package an IOC?
-            if		installTop is None \
-                and	(	os.path.split( self._packagePath )[0].startswith('ioc') \
-                    or  self._repo.GetUrl().find('ioc') >= 0 ):
-                # Package is an IOC
-                topVariants = [ epics_site_top ]
-                for topVariant in defEpicsTopVariants:
-                    topVariants.append( os.path.join( epics_site_top, topVariant ) )
-                for topVariant in topVariants:
-                    epics_ioc_top = os.path.join( topVariant, os.path.split(self._packagePath)[0] )
-                    if os.path.isdir( epics_ioc_top ):
-                        installTop = os.path.join( topVariant, self._packagePath )
-                        if not os.path.isdir( installTop ):
-                            os.makedirs( installTop, 0o775 )
  
             if not installTop:
                 print("InstallPackage Error: Unable to determine installTop!")

--- a/epics-release.py
+++ b/epics-release.py
@@ -320,7 +320,7 @@ try:
     if repo is None:
         raise ValidateError( "Can't establish a repo branch" )
 
-    pkgReleaser = Releaser( repo, packagePath, verbose=opt.verbose )
+    pkgReleaser = Releaser( repo, packagePath, installDir=opt.installDir, verbose=opt.verbose )
 
     # If removing old release, don't build or tag
     if	opt.nukeRelease:
@@ -361,17 +361,27 @@ try:
                 raise ValidateError("Unable to determine EPICS base version from RELEASE files")
         if not packageName:
             raise ValidateError("No release package specified")
-        if os.path.split( packagePath )[0] == 'modules':
-            if not epics_base_ver:
-                epics_base_ver = determine_epics_base_ver()
-            if not epics_base_ver:
-                raise ValidateError("Unable to determine EPICS base version")
+        if not epics_base_ver:
+            epics_base_ver = determine_epics_base_ver()
+        if not epics_base_ver:
+            raise ValidateError("Unable to determine EPICS base version")
+        if packagePath.find('github.com:') >= 0:
+            if packageName.find('ioc-') >= 0:
+                packageName.replace('-','/')
+            elif packageName.startswith('ext-'):
+                packageName.replace('ext-','extensions/')
+            elif packageName.startswith('extensions-'):
+                packageName.replace('-','/')
+            else: # Assume it's a module
+                packageName = os.path.join(	epics_base_ver, 'modules', packageName )
+            opt.installDir = os.path.join(	defaultEpicsSiteTop, packageName, opt.release	)
+        elif os.path.split( packagePath )[0] == 'modules':
             opt.installDir = os.path.join(	defaultEpicsSiteTop, epics_base_ver,
                                             packagePath, opt.release	)
         else:
             opt.installDir = os.path.join(	defaultEpicsSiteTop, packagePath, opt.release )
     pkgReleaser._installDir = opt.installDir
-    print("installDir:  %s" % repo.GetUrl())
+    print("installDir:  %s" % opt.installDir)
     print("repo_url:    %s" % repo.GetUrl())
     if opt.rmTag:
         print("rm tag:      %s" % opt.release)

--- a/epics-release.py
+++ b/epics-release.py
@@ -183,6 +183,8 @@ try:
                             keeptmp		= False	)
     parser.add_option(	"-r", "-R", "--release", dest="release",
                         help="release version string, ex. -r R1.2.3-0.1.0" )
+    parser.add_option(	"-u", "--url", dest="repo_url",
+                        help="repo URL, ex. -u git@github.com:/slac-epics/ADCore.git" )
     parser.add_option(	"-m", "--message", dest="message",
                         help="release message in quotes"	)
     parser.add_option(	"-v", "--verbose", dest="verbose", action="store_true",
@@ -238,7 +240,7 @@ try:
     packagePath  = None
 
     # See if this is a git working dir
-    ( git_url, git_branch, git_tag ) = gitGetWorkingBranch()
+    ( git_url, git_branch, git_tag ) = gitGetWorkingBranch( repo_url=opt.repo_url, verbose=opt.verbose )
     repo_tag = git_tag
 
     if git_url:

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -62,12 +62,14 @@ class gitRepo( Repo.Repo ):
                 if len(gitOutput) == 1:
                     curSha = gitOutput[0]
 
-                # Get the tag SHA
+                # Get the commit for the tag
                 tagSha = None
-                cmdList = [ "git", "rev-parse", self._tag ]
+                cmdList = [ "git", "show-ref", "-d", self._tag ]
                 gitOutput = subprocess.check_output( cmdList, universal_newlines=True ).splitlines()
-                if len(gitOutput) == 1:
-                    tagSha = gitOutput[0]
+                if len(gitOutput) == 2:
+                    tag_commit_info = gitOutput[1].split()
+                    if len(tag_commit_info) == 2:
+                        tagSha = tag_commit_info[0]
 
                 # If they match, it's already checked out!
                 if curSha == tagSha:
@@ -116,8 +118,8 @@ class gitRepo( Repo.Repo ):
             # Refresh the tags
             # TODO: May fail if git repo is read-only
             if verbose:
-                print("CheckoutRelease running: git fetch origin refs/tags/%s" % self._tag)
-            cmdList = [ "git", "fetch", "origin", "refs/tags/" + self._tag ]
+                print("CheckoutRelease running: git fetch %s refs/tags/%s" % (self._url, self._tag))
+            cmdList = [ "git", "fetch", self._url, "refs/tags/" + self._tag ]
             subprocess.check_call( cmdList, stdout=outputPipe, stderr=outputPipe )
 
             tagSha = gitGetTagSha( self._tag )
@@ -170,7 +172,7 @@ class gitRepo( Repo.Repo ):
         if verbose:
             print("\nRemoving %s release tag %s ..." % ( package, tag ))
         subprocess.check_call( [ "git", "tag", "-d", tag ] )
-        subprocess.check_call( [ 'git', 'push', '--delete', 'origin', tag ] )
+        subprocess.check_call( [ 'git', 'push', '--delete', self._url, tag ] )
         print("Successfully removed %s release tag %s." % ( package, tag ))
 
     def PushBranch( self, branchName=None, verbose=True, dryRun=False ):
@@ -186,7 +188,7 @@ class gitRepo( Repo.Repo ):
             return
         if verbose:
             print("Pushing branch %s ..." % ( branchName ))
-        subprocess.check_call( [ 'git', 'push', 'origin', branchName ] )
+        subprocess.check_call( [ 'git', 'push', self._url, branchName ] )
 
     def PushTag( self, release, verbose=True, dryRun=False ):
         if dryRun:
@@ -195,7 +197,7 @@ class gitRepo( Repo.Repo ):
 
         if verbose:
             print("Pushing tag %s ..." % ( release ))
-        subprocess.check_call( [ 'git', 'push', 'origin', release ] )
+        subprocess.check_call( [ 'git', 'push', self._url, release ] )
 
     def TagRelease( self, packagePath=None, release=None, branch=None, message="", verbose=True, dryRun=False ):
         if release is None:
@@ -209,8 +211,8 @@ class gitRepo( Repo.Repo ):
         comment = "Release %s/%s: %s" % ( packagePath, release, message )
         cmdList = [ "git", "tag", release, 'HEAD', "-m", comment ]
         subprocess.check_call( cmdList )
-        subprocess.check_call( [ 'git', 'push', '-u', 'origin' ] )
-        subprocess.check_call( [ 'git', 'push', 'origin', release ] )
+        subprocess.check_call( [ 'git', 'push', '-u', self._url, ] )
+        subprocess.check_call( [ 'git', 'push', self._url, release ] )
 
     def isDirty( self ):
         try:

--- a/gitRepo.py
+++ b/gitRepo.py
@@ -26,7 +26,7 @@ class gitRepo( Repo.Repo ):
         return strRep
 
     def GetWorkingBranch( self ):
-        return gitGetWorkingBranch()
+        return gitGetWorkingBranch(repo_url=self._url)
 
     def GetDefaultPackage( self, package, verbose=False ):
         return package

--- a/git_utils.py
+++ b/git_utils.py
@@ -424,10 +424,18 @@ def determinePathToGitRepo( packagePath, verbose = False ):
     # Check under the root of the git repo area for a bare repo w/ the right name
     gitRoot = determineGitRoot()
     gitPackageDir  = packageName + ".git"
+    if verbose:
+        print( "determinePathToGitRepo: gitRoot is %s" % gitRoot if gitRoot else None )
 
-    # If we're using github.com for our root, just add the package name
+    # Check github DEF_GITHUB_REPOS, just add the package name
+    defRepoPath = DEF_GITHUB_REPOS + '/' + gitPackageDir
     if 'github.com' in gitRoot:
-        return gitRoot + '/' + gitPackageDir
+        # This results in an extra github API access, but is needed to test if the package is hosted on github
+        repoTags = gitGetRemoteTags( defRepoPath, verbose=verbose )
+        if len(repoTags) > 0:
+            if verbose:
+                print( "determinePathToGitRepo: github %s repo is %s" % (packagePath, defRepoPath) )
+            return defRepoPath
 
     gitPackagePath = packagePath + ".git"
     if not os.path.isdir( DEF_CVS_ROOT ) and gitRoot:
@@ -484,7 +492,7 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
         print("gitFindPackageRelease: packageName=%s, packagePath=%s" % ( packageName, packagePath ))
 
     # See if the package was listed in $TOOLS/eco_modulelist/modulelist.txt
-    if not packageName in git_package2Location and not 'github.com' in DEF_GIT_REPO_PATH:
+    if not packageName in git_package2Location and not 'github.com' in DEF_GIT_REPO_PATH: 
         for url_root in [ DEF_GIT_MODULES_PATH, DEF_GIT_EXTENSIONS_PATH, DEF_GIT_EPICS_PATH, DEF_GIT_REPO_PATH ]:
             if repo_url is not None:
                 break
@@ -515,6 +523,8 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
     if verbose:
         if repo_url:
             print("gitFindPackageRelease found %s/%s: url=%s, tag=%s" % ( packagePath, tag, repo_url, repo_tag ))
+        elif url_path is None:
+            print("gitFindPackageRelease Error: Cannot determine URL for repo %s/%s" % (packagePath, tag))
         else:
             print("gitFindPackageRelease Error: Cannot find %s/%s" % (packagePath, tag))
     return (repo_url, repo_tag)

--- a/git_utils.py
+++ b/git_utils.py
@@ -52,6 +52,8 @@ git_package2Location = parseGitModulesTxt()
 def determineGitRoot( ):
     '''Get the root folder for GIT repos at SLAC'''
     gitRoot = DEF_AFS_GIT_REPOS
+    if not os.path.exists( gitRoot ):
+        gitRoot = DEF_GITHUB_REPOS
     # The GIT_REPO_ROOT variable is mainly used when testing eco and is not something that we really expect from the environment.
     if "GIT_REPO_ROOT" in os.environ:
         gitRoot = os.environ["GIT_REPO_ROOT"]
@@ -394,6 +396,8 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
         if debug:
             print(e)
         pass
+    if verbose:
+        print( "gitGetWorkingBranch: url=%s, branch=%s, tag=%s" % ( repo_url, repo_branch if repo_branch else 'None', repo_tag if repo_tag else 'None' ) )
     return ( repo_url, repo_branch, repo_tag )
 
 def determinePathToGitRepo( packagePath, verbose = False ):
@@ -420,6 +424,11 @@ def determinePathToGitRepo( packagePath, verbose = False ):
     # Check under the root of the git repo area for a bare repo w/ the right name
     gitRoot = determineGitRoot()
     gitPackageDir  = packageName + ".git"
+
+    # If we're using github.com for our root, just add the package name
+    if 'github.com' in gitRoot:
+        return gitRoot + '/' + gitPackageDir
+
     gitPackagePath = packagePath + ".git"
     if not os.path.isdir( DEF_CVS_ROOT ) and gitRoot:
         # Must be offsite, assume gitRoot and an EPICS module path
@@ -475,7 +484,7 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
         print("gitFindPackageRelease: packageName=%s, packagePath=%s" % ( packageName, packagePath ))
 
     # See if the package was listed in $TOOLS/eco_modulelist/modulelist.txt
-    if not packageName in git_package2Location and not 'github.com' in DEF_GIT_REPO_PATH: 
+    if not packageName in git_package2Location:
         for url_root in [ DEF_GIT_MODULES_PATH, DEF_GIT_EXTENSIONS_PATH, DEF_GIT_EPICS_PATH, DEF_GIT_REPO_PATH ]:
             if repo_url is not None:
                 break
@@ -487,6 +496,12 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
                     break
                 if packageName == packagePath:
                     break
+
+    if not repo_url:
+        url_path = determinePathToGitRepo( packageName, verbose=verbose )
+        (repo_sha, repo_tag) = gitGetRemoteTag( url_path, tag, verbose=verbose )
+        if repo_sha:
+            repo_url = url_path
 
     if verbose:
         if repo_url:

--- a/git_utils.py
+++ b/git_utils.py
@@ -345,12 +345,11 @@ def createBranchFromTag( tag, branchName ):
     subprocess.check_call(['git', 'checkout', '-q', tag])
     subprocess.check_call(['git', 'checkout', '-b', branchName])
 
-def gitGetWorkingBranch( debug = False, verbose = False ):
+def gitGetWorkingBranch( repo_url = None, debug = False, verbose = False ):
     '''See if the current directory is the top of an git working directory.
     Returns a 3-tuple of ( url, branch, tag ), ( None, None, None ) on error.
     For a valid git working dir, url must be a valid string, branch is the branch name or None if detached,
     tag is either None or a tag name if HEAD refers to a tag name.'''
-    repo_url    = None
     repo_branch = None
     repo_tag    = None
     try:
@@ -360,26 +359,27 @@ def gitGetWorkingBranch( debug = False, verbose = False ):
         if len(statusLines) > 0 and statusLines[0].startswith( 'refs/heads/' ):
             repo_branch = statusLines[0].split('/')[2]
 
-        repoCmd = [ 'git', 'remote', '-v' ]
-        statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
-        statusLines = statusInfo.splitlines()
-        for line in statusLines:
-            if line is None:
-                break
-            tokens = line.split()
-            if tokens[0] == 'origin':			# Use remote 'origin' if found
-                repo_url = tokens[1]
-                break
-            if tokens[0].find('origin') >= 0:	# Backup is last remote containing 'origin'
-                repo_url = tokens[1]
-            if repo_url is None:				# If all else fails just use first remote
-                repo_url = tokens[1]
+        if not repo_url:
+            repoCmd = [ 'git', 'remote', '-v' ]
+            statusInfo = subprocess.check_output( repoCmd, stderr=subprocess.STDOUT, universal_newlines=True )
+            statusLines = statusInfo.splitlines()
+            for line in statusLines:
+                if line is None:
+                    break
+                tokens = line.split()
+                if tokens[0] == 'origin':			# Use remote 'origin' if found
+                    repo_url = tokens[1]
+                    break
+                if tokens[0].find('origin') >= 0:	# Backup is last remote containing 'origin'
+                    repo_url = tokens[1]
+                if repo_url is None:				# If all else fails just use first remote
+                    repo_url = tokens[1]
 
-        if repo_url:
-            # Remove any trailing path separator
-            ( repoPath, repoPkg ) = os.path.split( repo_url )
-            if not repoPkg:
-                repo_url = repoPath
+            if repo_url:
+                # Remove any trailing path separator
+                ( repoPath, repoPkg ) = os.path.split( repo_url )
+                if not repoPkg:
+                    repo_url = repoPath
 
         # See if HEAD corresponds to any tags
         statusInfo = subprocess.check_output( [ 'git', 'name-rev', '--name-only', '--tags', 'HEAD' ], stderr=subprocess.STDOUT, universal_newlines=True )

--- a/git_utils.py
+++ b/git_utils.py
@@ -370,16 +370,13 @@ def gitGetWorkingBranch( repo_url = None, debug = False, verbose = False ):
                 if tokens[0] == 'origin':			# Use remote 'origin' if found
                     repo_url = tokens[1]
                     break
+                if tokens[1].find('github.com') and tokens[1].find('slac-epics/') >= 0:
+                    repo_url = tokens[1]
+                    break
                 if tokens[0].find('origin') >= 0:	# Backup is last remote containing 'origin'
                     repo_url = tokens[1]
                 if repo_url is None:				# If all else fails just use first remote
                     repo_url = tokens[1]
-
-            if repo_url:
-                # Remove any trailing path separator
-                ( repoPath, repoPkg ) = os.path.split( repo_url )
-                if not repoPkg:
-                    repo_url = repoPath
 
         # See if HEAD corresponds to any tags
         statusInfo = subprocess.check_output( [ 'git', 'name-rev', '--name-only', '--tags', 'HEAD' ], stderr=subprocess.STDOUT, universal_newlines=True )

--- a/git_utils.py
+++ b/git_utils.py
@@ -484,7 +484,7 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
         print("gitFindPackageRelease: packageName=%s, packagePath=%s" % ( packageName, packagePath ))
 
     # See if the package was listed in $TOOLS/eco_modulelist/modulelist.txt
-    if not packageName in git_package2Location:
+    if not packageName in git_package2Location and not 'github.com' in DEF_GIT_REPO_PATH:
         for url_root in [ DEF_GIT_MODULES_PATH, DEF_GIT_EXTENSIONS_PATH, DEF_GIT_EPICS_PATH, DEF_GIT_REPO_PATH ]:
             if repo_url is not None:
                 break
@@ -498,10 +498,19 @@ def gitFindPackageRelease( packageSpec, tag, debug = False, verbose = False ):
                     break
 
     if not repo_url:
-        url_path = determinePathToGitRepo( packageName, verbose=verbose )
+        # Try our github repos
+        url_path = DEF_GITHUB_REPOS + '/' + packageName + ".git"
         (repo_sha, repo_tag) = gitGetRemoteTag( url_path, tag, verbose=verbose )
         if repo_sha:
             repo_url = url_path
+
+    if not repo_url:
+        # Try full set of alternatives
+        url_path = determinePathToGitRepo( packageName, verbose=verbose )
+        if url_path:
+            (repo_sha, repo_tag) = gitGetRemoteTag( url_path, tag, verbose=verbose )
+            if repo_sha:
+                repo_url = url_path
 
     if verbose:
         if repo_url:


### PR DESCRIPTION
These commits were all previously on the epics-build-on-rocky9 branch, but I realized that they were all needed in order for epics-build and epics-release to work after moving nearly all of our repos from AFS to github.   These changes all work on both rhel7 and rhel9.